### PR TITLE
updated Escrow ledger entry type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### xrpl
 
 - Adds `PermissionedDomain` ledger entry type (XLS-80d).
+- Adds `TokenEscrow` support (XLS-85).
+
+### Fixed
+
+- Flatten function in Escrow transaction types for Destination and Owner fields.
 
 ## [v0.1.11]
 

--- a/examples/permissioned-dex/ws/main.go
+++ b/examples/permissioned-dex/ws/main.go
@@ -354,7 +354,7 @@ func main() {
 		return
 	}
 
-	offerNode := txResponse.Tx
+	offerNode := txResponse.TxJson
 	fmt.Printf("✅ Offer ledger object retrieved\n")
 	fmt.Printf("   📊 LedgerEntryType: %v\n", offerNode["LedgerEntryType"])
 	fmt.Printf("   🏷️  DomainID: %v\n", offerNode["DomainID"])

--- a/examples/token-escrow/rpc/main.go
+++ b/examples/token-escrow/rpc/main.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Peersyst/xrpl-go/pkg/crypto"
+	"github.com/Peersyst/xrpl-go/xrpl/currency"
+
+	"github.com/Peersyst/xrpl-go/xrpl/faucet"
+	"github.com/Peersyst/xrpl-go/xrpl/rpc"
+	"github.com/Peersyst/xrpl-go/xrpl/rpc/types"
+	rippleTime "github.com/Peersyst/xrpl-go/xrpl/time"
+	transactions "github.com/Peersyst/xrpl-go/xrpl/transaction"
+	txnTypes "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/Peersyst/xrpl-go/xrpl/wallet"
+)
+
+func main() {
+
+	//
+	// Configure client
+	//
+	fmt.Println("⏳ Setting up client...")
+	cfg, err := rpc.NewClientConfig(
+		"https://s.devnet.rippletest.net:51234/",
+		rpc.WithFaucetProvider(faucet.NewDevnetFaucetProvider()),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	client := rpc.NewClient(cfg)
+	fmt.Println("✅ Client configured!")
+	fmt.Println()
+
+	// Configure wallets
+	issuerWallet, holderWallet, holderWallet2 := createWallets(client)
+
+	// Configure issuer wallet to allow trust line locking
+	configureIssuerWallet(client, issuerWallet)
+
+	// Create trust line from holder to issuer
+	createTrustLine(client, issuerWallet, holderWallet, holderWallet2)
+
+	// Mint token from issuer to holder
+	mintToken(client, issuerWallet, holderWallet)
+
+	// Create escrow, the holder will escrow 100 tokens to the issuer
+	offerSequence := createEscrow(client, issuerWallet, holderWallet, holderWallet2)
+
+	// Finish escrow
+	finishEscrow(client, holderWallet, holderWallet2, offerSequence)
+}
+
+// createWallets configures the issuer and holder wallets.
+func createWallets(client *rpc.Client) (issuerWallet, holderWallet, holderWallet2 wallet.Wallet) {
+	fmt.Println("⏳ Setting up wallets...")
+	issuerWallet, err := wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating issuer wallet: %s\n", err)
+		return
+	}
+	err = client.FundWallet(&issuerWallet)
+	if err != nil {
+		fmt.Printf("❌ Error funding issuer wallet: %s\n", err)
+		return
+	}
+	fmt.Println("💸 Issuer wallet funded!")
+
+	// Holder wallet
+	holderWallet, err = wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating holder wallet: %s\n", err)
+		return
+	}
+	err = client.FundWallet(&holderWallet)
+	if err != nil {
+		fmt.Printf("❌ Error funding holder wallet: %s\n", err)
+		return
+	}
+	fmt.Println("💸 Holder wallet funded!")
+
+	// Holder wallet 2
+	holderWallet2, err = wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating holder wallet 2: %s\n", err)
+		return
+	}
+	err = client.FundWallet(&holderWallet2)
+	if err != nil {
+		fmt.Printf("❌ Error funding holder wallet 2: %s\n", err)
+		return
+	}
+	fmt.Println("💸 Holder wallet 2 funded!")
+
+	fmt.Println("✅ Wallets setup complete!")
+	fmt.Println("💳 Issuer wallet:", issuerWallet.ClassicAddress)
+	fmt.Println("💳 Holder wallet:", holderWallet.ClassicAddress)
+	fmt.Println("💳 Holder wallet 2:", holderWallet2.ClassicAddress)
+	fmt.Println()
+
+	return issuerWallet, holderWallet, holderWallet2
+}
+
+// configureIssuerWallet configures the issuer wallet to allow trust line locking.
+func configureIssuerWallet(client *rpc.Client, issuerWallet wallet.Wallet) {
+	fmt.Println("⏳ Configuring issuer wallet...")
+	accountSet := &transactions.AccountSet{
+		BaseTx: transactions.BaseTx{
+			Account: issuerWallet.ClassicAddress,
+		},
+	}
+	accountSet.SetAsfAllowTrustLineLocking()
+	accountSetResponse, err := client.SubmitTxAndWait(accountSet.Flatten(), &types.SubmitOptions{
+		Autofill: true,
+		Wallet:   &issuerWallet,
+	})
+	if err != nil {
+		fmt.Printf("❌ Error configuring issuer wallet: %s\n", err)
+		return
+	}
+	fmt.Println("✅ Issuer wallet configured!")
+	fmt.Printf("🌐 Hash: %s\n", accountSetResponse.Hash.String())
+	fmt.Println()
+}
+
+// createTrustLine creates a trust line for the holder wallet.
+func createTrustLine(client *rpc.Client, issuerWallet, holderWallet, holderWallet2 wallet.Wallet) {
+	fmt.Println("⏳ Creating trust line for holder wallet...")
+	trustLine := &transactions.TrustSet{
+		BaseTx: transactions.BaseTx{
+			Account: holderWallet.ClassicAddress,
+		},
+		LimitAmount: txnTypes.IssuedCurrencyAmount{
+			Issuer:   issuerWallet.ClassicAddress,
+			Currency: currency.ConvertStringToHex("ABCD"),
+			Value:    "1000000",
+		},
+	}
+	trustLine.SetSetNoRippleFlag()
+	trustLineResponse, err := client.SubmitTxAndWait(trustLine.Flatten(), &types.SubmitOptions{
+		Autofill: true,
+		Wallet:   &holderWallet,
+	})
+	if err != nil {
+		fmt.Printf("❌ Error creating trust line: %s\n", err)
+		return
+	}
+	fmt.Println("✅ Trust line created for holder wallet!")
+	fmt.Printf("🌐 Hash: %s\n", trustLineResponse.Hash.String())
+	fmt.Println()
+
+	fmt.Println("⏳ Creating trust line for holder wallet 2...")
+	trustLine = &transactions.TrustSet{
+		BaseTx: transactions.BaseTx{
+			Account: holderWallet2.ClassicAddress,
+		},
+		LimitAmount: txnTypes.IssuedCurrencyAmount{
+			Issuer:   issuerWallet.ClassicAddress,
+			Currency: currency.ConvertStringToHex("ABCD"),
+			Value:    "1000000",
+		},
+	}
+	trustLine.SetSetNoRippleFlag()
+	trustLineResponse, err = client.SubmitTxAndWait(trustLine.Flatten(), &types.SubmitOptions{
+		Autofill: true,
+		Wallet:   &holderWallet2,
+	})
+	if err != nil {
+		fmt.Printf("❌ Error creating trust line: %s\n", err)
+		return
+	}
+	fmt.Println("✅ Trust line created for holder wallet 2!")
+	fmt.Printf("🌐 Hash: %s\n", trustLineResponse.Hash.String())
+	fmt.Println()
+}
+
+// mintToken mints a token for the holder wallet.
+func mintToken(client *rpc.Client, issuerWallet, holderWallet wallet.Wallet) {
+	fmt.Println("⏳ Minting token to holder wallet...")
+	token := &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: issuerWallet.ClassicAddress,
+		},
+		Destination: holderWallet.ClassicAddress,
+		Amount: txnTypes.IssuedCurrencyAmount{
+			Issuer:   issuerWallet.ClassicAddress,
+			Currency: currency.ConvertStringToHex("ABCD"),
+			Value:    "10000",
+		},
+	}
+	tokenResponse, err := client.SubmitTxAndWait(token.Flatten(), &types.SubmitOptions{
+		Autofill: true,
+		Wallet:   &issuerWallet,
+	})
+	if err != nil {
+		fmt.Printf("❌ Error minting token: %s\n", err)
+		return
+	}
+	fmt.Println("✅ Token minted!")
+	fmt.Printf("🌐 Hash: %s\n", tokenResponse.Hash.String())
+	fmt.Println()
+}
+
+// createEscrow creates an escrow for the holder wallet.
+func createEscrow(client *rpc.Client, issuerWallet, holderWallet, holderWallet2 wallet.Wallet) (offerSequence uint32) {
+	fmt.Println("⏳ Creating escrow...")
+	escrow := &transactions.EscrowCreate{
+		BaseTx: transactions.BaseTx{
+			Account: holderWallet.ClassicAddress,
+		},
+		Amount: txnTypes.IssuedCurrencyAmount{
+			Issuer:   issuerWallet.ClassicAddress,
+			Currency: currency.ConvertStringToHex("ABCD"),
+			Value:    "100",
+		},
+		Destination: holderWallet2.ClassicAddress,
+		CancelAfter: uint32(rippleTime.UnixTimeToRippleTime(time.Now().Unix()) + 4000),
+		FinishAfter: uint32(rippleTime.UnixTimeToRippleTime(time.Now().Unix() + 5)),
+	}
+	escrowResponse, err := client.SubmitTxAndWait(escrow.Flatten(), &types.SubmitOptions{
+		Autofill: true,
+		Wallet:   &holderWallet,
+	})
+	if err != nil {
+		fmt.Printf("❌ Error creating escrow: %s\n", err)
+		return
+	}
+	fmt.Println("✅ Escrow created!")
+	fmt.Printf("🌐 Hash: %s\n", escrowResponse.Hash.String())
+	fmt.Printf("🌐 Sequence: %d\n", escrowResponse.TxJson.Sequence())
+	fmt.Println()
+
+	return escrowResponse.TxJson.Sequence()
+
+}
+
+// finishEscrow finishes the escrow for the holder wallet 2.
+func finishEscrow(client *rpc.Client, holderWallet, holderWallet2 wallet.Wallet, offerSequence uint32) {
+	fmt.Println("⏳ Finishing escrow...")
+	escrow := &transactions.EscrowFinish{
+		BaseTx: transactions.BaseTx{
+			Account: holderWallet2.ClassicAddress,
+		},
+		Owner:         holderWallet.ClassicAddress,
+		OfferSequence: offerSequence,
+	}
+	escrowResponse, err := client.SubmitTxAndWait(escrow.Flatten(), &types.SubmitOptions{
+		Autofill: true,
+		Wallet:   &holderWallet2,
+	})
+	if err != nil {
+		fmt.Printf("❌ Error finishing escrow: %s\n", err)
+		return
+	}
+	fmt.Println("✅ Escrow finished!")
+	fmt.Printf("🌐 Hash: %s\n", escrowResponse.Hash.String())
+	fmt.Println()
+}

--- a/examples/token-escrow/ws/main.go
+++ b/examples/token-escrow/ws/main.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Peersyst/xrpl-go/pkg/crypto"
+	"github.com/Peersyst/xrpl-go/xrpl/currency"
+	"github.com/Peersyst/xrpl-go/xrpl/websocket"
+
+	"github.com/Peersyst/xrpl-go/xrpl/faucet"
+	rippleTime "github.com/Peersyst/xrpl-go/xrpl/time"
+	transactions "github.com/Peersyst/xrpl-go/xrpl/transaction"
+	txnTypes "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/Peersyst/xrpl-go/xrpl/wallet"
+	wstypes "github.com/Peersyst/xrpl-go/xrpl/websocket/types"
+)
+
+func main() {
+
+	//
+	// Configure client
+	//
+	fmt.Println("⏳ Setting up client...")
+	client := websocket.NewClient(
+		websocket.NewClientConfig().
+			WithHost("wss://s.devnet.rippletest.net:51233").
+			WithFaucetProvider(faucet.NewDevnetFaucetProvider()),
+	)
+
+	defer func() {
+		if err := client.Disconnect(); err != nil {
+			fmt.Println("Error disconnecting:", err)
+		}
+	}()
+
+	fmt.Println("✅ Client configured!")
+	fmt.Println()
+
+	fmt.Println("Connecting to server...")
+	if err := client.Connect(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println("Connection: ", client.IsConnected())
+	fmt.Println()
+
+	// Configure wallets
+	issuerWallet, holderWallet, holderWallet2 := createWallets(client)
+
+	// Configure issuer wallet to allow trust line locking
+	configureIssuerWallet(client, issuerWallet)
+
+	// Create trust line from holder to issuer
+	createTrustLine(client, issuerWallet, holderWallet, holderWallet2)
+
+	// Mint token from issuer to holder
+	mintToken(client, issuerWallet, holderWallet)
+
+	// Create escrow, the holder will escrow 100 tokens to the issuer
+	offerSequence := createEscrow(client, issuerWallet, holderWallet, holderWallet2)
+
+	// Finish escrow
+	finishEscrow(client, holderWallet, holderWallet2, offerSequence)
+}
+
+// createWallets configures the issuer and holder wallets.
+func createWallets(client *websocket.Client) (issuerWallet, holderWallet, holderWallet2 wallet.Wallet) {
+	fmt.Println("⏳ Setting up wallets...")
+	issuerWallet, err := wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating issuer wallet: %s\n", err)
+		return
+	}
+	err = client.FundWallet(&issuerWallet)
+	if err != nil {
+		fmt.Printf("❌ Error funding issuer wallet: %s\n", err)
+		return
+	}
+	fmt.Println("💸 Issuer wallet funded!")
+
+	// Holder wallet
+	holderWallet, err = wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating holder wallet: %s\n", err)
+		return
+	}
+	err = client.FundWallet(&holderWallet)
+	if err != nil {
+		fmt.Printf("❌ Error funding holder wallet: %s\n", err)
+		return
+	}
+	fmt.Println("💸 Holder wallet funded!")
+
+	// Holder wallet 2
+	holderWallet2, err = wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating holder wallet 2: %s\n", err)
+		return
+	}
+	err = client.FundWallet(&holderWallet2)
+	if err != nil {
+		fmt.Printf("❌ Error funding holder wallet 2: %s\n", err)
+		return
+	}
+	fmt.Println("💸 Holder wallet 2 funded!")
+
+	fmt.Println("✅ Wallets setup complete!")
+	fmt.Println("💳 Issuer wallet:", issuerWallet.ClassicAddress)
+	fmt.Println("💳 Holder wallet:", holderWallet.ClassicAddress)
+	fmt.Println("💳 Holder wallet 2:", holderWallet2.ClassicAddress)
+	fmt.Println()
+
+	return issuerWallet, holderWallet, holderWallet2
+}
+
+// configureIssuerWallet configures the issuer wallet to allow trust line locking.
+func configureIssuerWallet(client *websocket.Client, issuerWallet wallet.Wallet) {
+	fmt.Println("⏳ Configuring issuer wallet...")
+	accountSet := &transactions.AccountSet{
+		BaseTx: transactions.BaseTx{
+			Account: issuerWallet.ClassicAddress,
+		},
+	}
+	accountSet.SetAsfAllowTrustLineLocking()
+	accountSetResponse, err := client.SubmitTxAndWait(accountSet.Flatten(), &wstypes.SubmitOptions{
+		Autofill: true,
+		Wallet:   &issuerWallet,
+	})
+	if err != nil {
+		fmt.Printf("❌ Error configuring issuer wallet: %s\n", err)
+		return
+	}
+	fmt.Println("✅ Issuer wallet configured!")
+	fmt.Printf("🌐 Hash: %s\n", accountSetResponse.Hash.String())
+	fmt.Println()
+}
+
+// createTrustLine creates a trust line for the holder wallet.
+func createTrustLine(client *websocket.Client, issuerWallet, holderWallet, holderWallet2 wallet.Wallet) {
+	fmt.Println("⏳ Creating trust line for holder wallet...")
+	trustLine := &transactions.TrustSet{
+		BaseTx: transactions.BaseTx{
+			Account: holderWallet.ClassicAddress,
+		},
+		LimitAmount: txnTypes.IssuedCurrencyAmount{
+			Issuer:   issuerWallet.ClassicAddress,
+			Currency: currency.ConvertStringToHex("ABCD"),
+			Value:    "1000000",
+		},
+	}
+	trustLine.SetSetNoRippleFlag()
+	trustLineResponse, err := client.SubmitTxAndWait(trustLine.Flatten(), &wstypes.SubmitOptions{
+		Autofill: true,
+		Wallet:   &holderWallet,
+	})
+	if err != nil {
+		fmt.Printf("❌ Error creating trust line: %s\n", err)
+		return
+	}
+	fmt.Println("✅ Trust line created for holder wallet!")
+	fmt.Printf("🌐 Hash: %s\n", trustLineResponse.Hash.String())
+	fmt.Println()
+
+	fmt.Println("⏳ Creating trust line for holder wallet 2...")
+	trustLine = &transactions.TrustSet{
+		BaseTx: transactions.BaseTx{
+			Account: holderWallet2.ClassicAddress,
+		},
+		LimitAmount: txnTypes.IssuedCurrencyAmount{
+			Issuer:   issuerWallet.ClassicAddress,
+			Currency: currency.ConvertStringToHex("ABCD"),
+			Value:    "1000000",
+		},
+	}
+	trustLine.SetSetNoRippleFlag()
+	trustLineResponse, err = client.SubmitTxAndWait(trustLine.Flatten(), &wstypes.SubmitOptions{
+		Autofill: true,
+		Wallet:   &holderWallet2,
+	})
+	if err != nil {
+		fmt.Printf("❌ Error creating trust line: %s\n", err)
+		return
+	}
+	fmt.Println("✅ Trust line created for holder wallet 2!")
+	fmt.Printf("🌐 Hash: %s\n", trustLineResponse.Hash.String())
+	fmt.Println()
+}
+
+// mintToken mints a token for the holder wallet.
+func mintToken(client *websocket.Client, issuerWallet, holderWallet wallet.Wallet) {
+	fmt.Println("⏳ Minting token to holder wallet...")
+	token := &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: issuerWallet.ClassicAddress,
+		},
+		Destination: holderWallet.ClassicAddress,
+		Amount: txnTypes.IssuedCurrencyAmount{
+			Issuer:   issuerWallet.ClassicAddress,
+			Currency: currency.ConvertStringToHex("ABCD"),
+			Value:    "10000",
+		},
+	}
+	tokenResponse, err := client.SubmitTxAndWait(token.Flatten(), &wstypes.SubmitOptions{
+		Autofill: true,
+		Wallet:   &issuerWallet,
+	})
+	if err != nil {
+		fmt.Printf("❌ Error minting token: %s\n", err)
+		return
+	}
+	fmt.Println("✅ Token minted!")
+	fmt.Printf("🌐 Hash: %s\n", tokenResponse.Hash.String())
+	fmt.Println()
+}
+
+// createEscrow creates an escrow for the holder wallet.
+func createEscrow(client *websocket.Client, issuerWallet, holderWallet, holderWallet2 wallet.Wallet) (offerSequence uint32) {
+	fmt.Println("⏳ Creating escrow...")
+	escrow := &transactions.EscrowCreate{
+		BaseTx: transactions.BaseTx{
+			Account: holderWallet.ClassicAddress,
+		},
+		Amount: txnTypes.IssuedCurrencyAmount{
+			Issuer:   issuerWallet.ClassicAddress,
+			Currency: currency.ConvertStringToHex("ABCD"),
+			Value:    "100",
+		},
+		Destination: holderWallet2.ClassicAddress,
+		CancelAfter: uint32(rippleTime.UnixTimeToRippleTime(time.Now().Unix()) + 4000),
+		FinishAfter: uint32(rippleTime.UnixTimeToRippleTime(time.Now().Unix() + 5)),
+	}
+	escrowResponse, err := client.SubmitTxAndWait(escrow.Flatten(), &wstypes.SubmitOptions{
+		Autofill: true,
+		Wallet:   &holderWallet,
+	})
+	if err != nil {
+		fmt.Printf("❌ Error creating escrow: %s\n", err)
+		return
+	}
+	fmt.Println("✅ Escrow created!")
+	fmt.Printf("🌐 Hash: %s\n", escrowResponse.Hash.String())
+	fmt.Printf("🌐 Sequence: %d\n", escrowResponse.TxJson.Sequence())
+	fmt.Println()
+
+	return escrowResponse.TxJson.Sequence()
+
+}
+
+// finishEscrow finishes the escrow for the holder wallet 2.
+func finishEscrow(client *websocket.Client, holderWallet, holderWallet2 wallet.Wallet, offerSequence uint32) {
+	fmt.Println("⏳ Finishing escrow...")
+	escrow := &transactions.EscrowFinish{
+		BaseTx: transactions.BaseTx{
+			Account: holderWallet2.ClassicAddress,
+		},
+		Owner:         holderWallet.ClassicAddress,
+		OfferSequence: offerSequence,
+	}
+	escrowResponse, err := client.SubmitTxAndWait(escrow.Flatten(), &wstypes.SubmitOptions{
+		Autofill: true,
+		Wallet:   &holderWallet2,
+	})
+	if err != nil {
+		fmt.Printf("❌ Error finishing escrow: %s\n", err)
+		return
+	}
+	fmt.Println("✅ Escrow finished!")
+	fmt.Printf("🌐 Hash: %s\n", escrowResponse.Hash.String())
+	fmt.Println()
+}

--- a/xrpl/ledger-entry-types/account_root.go
+++ b/xrpl/ledger-entry-types/account_root.go
@@ -8,6 +8,8 @@ import (
 const (
 	// Enable Clawback for this account. (Requires the Clawback amendment.)
 	lsfAllowTrustLineClawback uint32 = 0x80000000
+	// Allow IOUs to be used as escrow amounts for an issuer
+	lsfAllowTrustLineLocking uint32 = 0x40000000
 	// Enable rippling on this addresses's trust lines by default. Required for issuing addresses; discouraged for others.
 	lsfDefaultRipple uint32 = 0x00800000
 	// This account has DepositAuth enabled, meaning it can only receive funds from transactions it sends, and from preauthorized accounts. (Added by the DepositAuth amendment)
@@ -134,6 +136,11 @@ func (*AccountRoot) EntryType() EntryType {
 // SetLsfAllowTrustLineClawback sets the AllowTrustLineClawback flag.
 func (a *AccountRoot) SetLsfAllowTrustLineClawback() {
 	a.Flags |= lsfAllowTrustLineClawback
+}
+
+// SetLsfAllowTrustLineLocking sets the AllowTrustLineLocking flag.
+func (a *AccountRoot) SetLsfAllowTrustLineLocking() {
+	a.Flags |= lsfAllowTrustLineLocking
 }
 
 // SetLsfDefaultRipple sets the DefaultRipple flag.

--- a/xrpl/ledger-entry-types/escrow.go
+++ b/xrpl/ledger-entry-types/escrow.go
@@ -1,6 +1,8 @@
 package ledger
 
 import (
+	"encoding/json"
+
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
 
@@ -23,7 +25,9 @@ import (
 //	    "PreviousTxnID": "C44F2EB84196B9AD820313DBEBA6316A15C9A2D35787579ED172B87A30131DA7",
 //	    "PreviousTxnLgrSeq": 28991004,
 //	    "SourceTag": 11747,
-//	    "index": "DC5F3851D8A1AB622F957761E5963BC5BD439D5C24AC6AD7AC4523F0640244AC"
+//	    "index": "DC5F3851D8A1AB622F957761E5963BC5BD439D5C24AC6AD7AC4523F0640244AC",
+//	    "TransferRate": 1000,
+//	    "IssuerNode": 1234567890
 //	}
 //
 // ```
@@ -39,8 +43,9 @@ type Escrow struct {
 	// The address of the owner (sender) of this escrow. This is the account that provided the XRP,
 	// and gets it back if the escrow is canceled.
 	Account types.Address
-	// The amount of XRP, in drops, currently held in the escrow.
-	Amount types.XRPCurrencyAmount
+	// Amount of XRP or fungible tokens to deduct from the sender's balance and escrow.
+	// Once escrowed, the payment can either go to the Destination address (after the FinishAfter time) or be returned to the sender (after the CancelAfter time).
+	Amount types.CurrencyAmount
 	// The escrow can be canceled if and only if this field is present and the time it specifies has passed.
 	// Specifically, this is specified as seconds since the Ripple Epoch and it "has passed" if it's
 	// earlier than the close time of the previous validated ledger.
@@ -67,9 +72,64 @@ type Escrow struct {
 	PreviousTxnLgrSeq uint32
 	// An arbitrary tag to further specify the source for this escrow, such as a hosted recipient at the owner's address.
 	SourceTag uint32 `json:",omitempty"`
+	// The fee to charge when users finish an escrow, initially set on the creation of an escrow contract and updated on subsequent finish transactions.
+	TransferRate uint32 `json:",omitempty"`
+	// (Optional) The ledger index of the issuer's directory node associated with the Escrow. Used when the issuer is neither the source nor destination account.
+	IssuerNode uint64 `json:",omitempty"`
 }
 
 // EntryType returns the ledger entry type for Escrow.
 func (*Escrow) EntryType() EntryType {
 	return EscrowEntry
+}
+
+// UnmarshalJSON implements custom JSON unmarshalling for Escrow.
+func (e *Escrow) UnmarshalJSON(data []byte) error {
+	type escrowHelper struct {
+		Index             types.Hash256 `json:"index,omitempty"`
+		LedgerEntryType   EntryType
+		Flags             uint32
+		Account           types.Address
+		Amount            json.RawMessage
+		CancelAfter       uint32 `json:",omitempty"`
+		Condition         string `json:",omitempty"`
+		Destination       types.Address
+		DestinationNode   string `json:",omitempty"`
+		DestinationTag    uint32 `json:",omitempty"`
+		FinishAfter       uint32 `json:",omitempty"`
+		OwnerNode         string
+		PreviousTxnID     types.Hash256
+		PreviousTxnLgrSeq uint32
+		SourceTag         uint32 `json:",omitempty"`
+		TransferRate      uint32 `json:",omitempty"`
+		IssuerNode        uint64 `json:",omitempty"`
+	}
+	var h escrowHelper
+	if err := json.Unmarshal(data, &h); err != nil {
+		return err
+	}
+	*e = Escrow{
+		Index:             h.Index,
+		LedgerEntryType:   h.LedgerEntryType,
+		Flags:             h.Flags,
+		Account:           h.Account,
+		CancelAfter:       h.CancelAfter,
+		Condition:         h.Condition,
+		Destination:       h.Destination,
+		DestinationNode:   h.DestinationNode,
+		DestinationTag:    h.DestinationTag,
+		FinishAfter:       h.FinishAfter,
+		OwnerNode:         h.OwnerNode,
+		PreviousTxnID:     h.PreviousTxnID,
+		PreviousTxnLgrSeq: h.PreviousTxnLgrSeq,
+		SourceTag:         h.SourceTag,
+		TransferRate:      h.TransferRate,
+		IssuerNode:        h.IssuerNode,
+	}
+	amount, err := types.UnmarshalCurrencyAmount(h.Amount)
+	if err != nil {
+		return err
+	}
+	e.Amount = amount
+	return nil
 }

--- a/xrpl/ledger-entry-types/escrow_test.go
+++ b/xrpl/ledger-entry-types/escrow_test.go
@@ -24,6 +24,8 @@ func TestEscrow(t *testing.T) {
 		PreviousTxnID:     "C44F2EB84196B9AD820313DBEBA6316A15C9A2D35787579ED172B87A30131DA7",
 		PreviousTxnLgrSeq: 28991004,
 		SourceTag:         11747,
+		TransferRate:      1000,
+		IssuerNode:        1234567890,
 	}
 
 	j := `{
@@ -40,7 +42,9 @@ func TestEscrow(t *testing.T) {
 	"OwnerNode": "0000000000000000",
 	"PreviousTxnID": "C44F2EB84196B9AD820313DBEBA6316A15C9A2D35787579ED172B87A30131DA7",
 	"PreviousTxnLgrSeq": 28991004,
-	"SourceTag": 11747
+	"SourceTag": 11747,
+	"TransferRate": 1000,
+	"IssuerNode": 1234567890
 }`
 
 	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
@@ -51,4 +55,106 @@ func TestEscrow(t *testing.T) {
 func TestEscrow_EntryType(t *testing.T) {
 	s := &Escrow{}
 	require.Equal(t, s.EntryType(), EscrowEntry)
+}
+
+func TestEscrowMPTAmountSerialization(t *testing.T) {
+	var s Object = &Escrow{
+		LedgerEntryType: EscrowEntry,
+		Flags:           0,
+		Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+		Amount: types.MPTCurrencyAmount{
+			MPTIssuanceID: "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+			Value:         "10000",
+		},
+		CancelAfter:       545440232,
+		Condition:         "A0258020A82A88B2DF843A54F58772E4A3861866ECDB4157645DD9AE528C1D3AEEDABAB6810120",
+		Destination:       "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+		DestinationNode:   "0000000000000000",
+		DestinationTag:    23480,
+		FinishAfter:       545354132,
+		OwnerNode:         "0000000000000000",
+		PreviousTxnID:     "C44F2EB84196B9AD820313DBEBA6316A15C9A2D35787579ED172B87A30131DA7",
+		PreviousTxnLgrSeq: 28991004,
+		SourceTag:         11747,
+		TransferRate:      1000,
+		IssuerNode:        1234567890,
+	}
+
+	j := `{
+	"LedgerEntryType": "Escrow",
+	"Flags": 0,
+	"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+	"Amount": {
+		"mpt_issuance_id": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+		"value": "10000"
+	},
+	"CancelAfter": 545440232,
+	"Condition": "A0258020A82A88B2DF843A54F58772E4A3861866ECDB4157645DD9AE528C1D3AEEDABAB6810120",
+	"Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+	"DestinationNode": "0000000000000000",
+	"DestinationTag": 23480,
+	"FinishAfter": 545354132,
+	"OwnerNode": "0000000000000000",
+	"PreviousTxnID": "C44F2EB84196B9AD820313DBEBA6316A15C9A2D35787579ED172B87A30131DA7",
+	"PreviousTxnLgrSeq": 28991004,
+	"SourceTag": 11747,
+	"TransferRate": 1000,
+	"IssuerNode": 1234567890
+}`
+
+	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestEscrowIssuedAmountSerialization(t *testing.T) {
+	var s Object = &Escrow{
+		LedgerEntryType: EscrowEntry,
+		Flags:           0,
+		Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+		Amount: types.IssuedCurrencyAmount{
+			Issuer:   "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+			Currency: "USD",
+			Value:    "10000",
+		},
+		CancelAfter:       545440232,
+		Condition:         "A0258020A82A88B2DF843A54F58772E4A3861866ECDB4157645DD9AE528C1D3AEEDABAB6810120",
+		Destination:       "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+		DestinationNode:   "0000000000000000",
+		DestinationTag:    23480,
+		FinishAfter:       545354132,
+		OwnerNode:         "0000000000000000",
+		PreviousTxnID:     "C44F2EB84196B9AD820313DBEBA6316A15C9A2D35787579ED172B87A30131DA7",
+		PreviousTxnLgrSeq: 28991004,
+		SourceTag:         11747,
+		TransferRate:      1000,
+		IssuerNode:        1234567890,
+	}
+
+	j := `{
+	"LedgerEntryType": "Escrow",
+	"Flags": 0,
+	"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+	"Amount": {
+		"issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+		"currency": "USD",
+		"value": "10000"
+	},
+	"CancelAfter": 545440232,
+	"Condition": "A0258020A82A88B2DF843A54F58772E4A3861866ECDB4157645DD9AE528C1D3AEEDABAB6810120",
+	"Destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+	"DestinationNode": "0000000000000000",
+	"DestinationTag": 23480,
+	"FinishAfter": 545354132,
+	"OwnerNode": "0000000000000000",
+	"PreviousTxnID": "C44F2EB84196B9AD820313DBEBA6316A15C9A2D35787579ED172B87A30131DA7",
+	"PreviousTxnLgrSeq": 28991004,
+	"SourceTag": 11747,
+	"TransferRate": 1000,
+	"IssuerNode": 1234567890
+}`
+
+	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
+		t.Error(err)
+	}
 }

--- a/xrpl/ledger-entry-types/mptoken_issuance.go
+++ b/xrpl/ledger-entry-types/mptoken_issuance.go
@@ -59,6 +59,8 @@ type MPTokenIssuance struct {
 	// The Sequence (or Ticket) number of the transaction that created this issuance.
 	// This helps to uniquely identify the issuance and distinguish it from any other later MPT issuances created by this account.
 	Sequence uint32
+	// The amount of tokens currently locked up (for example, in escrow or payment channels). (Requires the TokenEscrow amendment .)
+	LockedAmount uint64 `json:",omitempty"`
 }
 
 // EntryType returns the type of the ledger entry.

--- a/xrpl/queries/transactions/tx_request.go
+++ b/xrpl/queries/transactions/tx_request.go
@@ -50,5 +50,5 @@ type TxResponse struct {
 	// TODO: Improve Meta parsing
 	Meta      any                         `json:"meta"`
 	Validated bool                        `json:"validated"`
-	Tx        transaction.FlatTransaction `json:",omitempty"`
+	TxJson    transaction.FlatTransaction `json:"tx_json,omitempty"`
 }

--- a/xrpl/transaction/account_set.go
+++ b/xrpl/transaction/account_set.go
@@ -46,6 +46,8 @@ const (
 	asfDisallowIncomingTrustLine uint32 = 15
 	// Permanently gain the ability to claw back issued IOUs
 	asfAllowTrustLineClawback uint32 = 16
+	// Issuers allow their IOUs to be used as escrow amounts
+	asfAllowTrustLineLocking uint32 = 17
 
 	//
 	// Transaction Flags
@@ -334,6 +336,16 @@ func (s *AccountSet) ClearAsfAllowTrustLineClawback() {
 	s.ClearFlag = asfAllowTrustLineClawback
 }
 
+// SetAsfAllowTrustLineLocking sets the allow trust line locking flag.
+func (s *AccountSet) SetAsfAllowTrustLineLocking() {
+	s.SetFlag = asfAllowTrustLineLocking
+}
+
+// ClearAsfAllowTrustLineLocking clears the allow trust line locking flag.
+func (s *AccountSet) ClearAsfAllowTrustLineLocking() {
+	s.ClearFlag = asfAllowTrustLineLocking
+}
+
 // Validate the AccountSet transaction fields.
 func (s *AccountSet) Validate() (bool, error) {
 	flatten := s.Flatten()
@@ -396,7 +408,7 @@ func (s *AccountSet) Validate() (bool, error) {
 
 	// check if SetFlag is within the valid range
 	if s.SetFlag != 0 {
-		if s.SetFlag < asfRequireDest || s.SetFlag > asfAllowTrustLineClawback {
+		if s.SetFlag < asfRequireDest || s.SetFlag > asfAllowTrustLineLocking {
 			return false, ErrAccountSetInvalidSetFlag
 		}
 	}

--- a/xrpl/transaction/account_set_test.go
+++ b/xrpl/transaction/account_set_test.go
@@ -204,6 +204,13 @@ func TestAccountSetAsfFlags(t *testing.T) {
 			},
 			expected: asfAllowTrustLineClawback,
 		},
+		{
+			name: "pass - SetAsfAllowTrustLineLocking",
+			setter: func(s *AccountSet) {
+				s.SetAsfAllowTrustLineLocking()
+			},
+			expected: asfAllowTrustLineLocking,
+		},
 	}
 
 	for _, tt := range tests {
@@ -327,6 +334,13 @@ func TestAccountClearAsfFlags(t *testing.T) {
 				s.ClearAsfAllowTrustLineClawback()
 			},
 			expected: asfAllowTrustLineClawback,
+		},
+		{
+			name: "pass - ClearAsfAllowTrustLineLocking",
+			setter: func(s *AccountSet) {
+				s.ClearAsfAllowTrustLineLocking()
+			},
+			expected: asfAllowTrustLineLocking,
 		},
 	}
 

--- a/xrpl/transaction/escrow_cancel.go
+++ b/xrpl/transaction/escrow_cancel.go
@@ -39,7 +39,7 @@ func (e *EscrowCancel) Flatten() FlatTransaction {
 	flattened["TransactionType"] = "EscrowCancel"
 
 	if e.Owner != "" {
-		flattened["Owner"] = e.Owner
+		flattened["Owner"] = e.Owner.String()
 	}
 
 	if e.OfferSequence != 0 {

--- a/xrpl/transaction/escrow_create.go
+++ b/xrpl/transaction/escrow_create.go
@@ -57,7 +57,7 @@ func (e *EscrowCreate) Flatten() FlatTransaction {
 	flattened["Amount"] = e.Amount.Flatten()
 
 	if e.Destination != "" {
-		flattened["Destination"] = e.Destination
+		flattened["Destination"] = e.Destination.String()
 	}
 	if e.CancelAfter != 0 {
 		flattened["CancelAfter"] = e.CancelAfter

--- a/xrpl/transaction/escrow_create.go
+++ b/xrpl/transaction/escrow_create.go
@@ -1,6 +1,8 @@
 package transaction
 
 import (
+	"encoding/json"
+
 	addresscodec "github.com/Peersyst/xrpl-go/address-codec"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
@@ -26,8 +28,9 @@ import (
 // ```
 type EscrowCreate struct {
 	BaseTx
-	// Amount of XRP, in drops, to deduct from the sender's balance and escrow. Once escrowed, the XRP can either go to the Destination address (after the FinishAfter time) or returned to the sender (after the CancelAfter time).
-	Amount types.XRPCurrencyAmount
+	// Amount of XRP or fungible tokens to deduct from the sender's balance and escrow.
+	// Once escrowed, the payment can either go to the Destination address (after the FinishAfter time) or be returned to the sender (after the CancelAfter time).
+	Amount types.CurrencyAmount
 	// Address to receive escrowed XRP.
 	Destination types.Address
 	// (Optional) The time, in seconds since the Ripple Epoch, when this escrow expires. This value is immutable; the funds can only be returned to the sender after this time.
@@ -70,6 +73,37 @@ func (e *EscrowCreate) Flatten() FlatTransaction {
 	}
 
 	return flattened
+}
+
+// UnmarshalJSON implements custom JSON unmarshalling for EscrowCreate.
+func (e *EscrowCreate) UnmarshalJSON(data []byte) error {
+	type escrowCreateHelper struct {
+		BaseTx
+		Amount         json.RawMessage
+		Destination    types.Address
+		CancelAfter    uint32  `json:",omitempty"`
+		FinishAfter    uint32  `json:",omitempty"`
+		Condition      string  `json:",omitempty"`
+		DestinationTag *uint32 `json:",omitempty"`
+	}
+	var h escrowCreateHelper
+	if err := json.Unmarshal(data, &h); err != nil {
+		return err
+	}
+	*e = EscrowCreate{
+		BaseTx:         h.BaseTx,
+		Destination:    h.Destination,
+		CancelAfter:    h.CancelAfter,
+		FinishAfter:    h.FinishAfter,
+		Condition:      h.Condition,
+		DestinationTag: h.DestinationTag,
+	}
+	amount, err := types.UnmarshalCurrencyAmount(h.Amount)
+	if err != nil {
+		return err
+	}
+	e.Amount = amount
+	return nil
 }
 
 // Validate checks the EscrowCreate transaction fields for correctness.

--- a/xrpl/transaction/escrow_create_test.go
+++ b/xrpl/transaction/escrow_create_test.go
@@ -348,6 +348,97 @@ func TestEscrowCreate_Unmarshal(t *testing.T) {
 			expectedTag:          nil,
 			expectUnmarshalError: false,
 		},
+		{
+			name: "pass - full EscrowCreate with MPTAmount",
+			jsonData: `{
+				"TransactionType": "EscrowCreate",
+				"Account": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				"Destination": "rDEST123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				"Amount": {
+					"mpt_issuance_id": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+					"value": "1000000"
+				},
+				"Fee": "10",
+				"Sequence": 1,
+				"Flags": 2147483648,
+				"CancelAfter": 695123456,
+				"FinishAfter": 695000000,
+				"Condition": "A0258020C4F71E9B01F5A78023E932ABF6B2C1F020986E6C9E55678FFBAE67A2F5B474680103080000000000000000000000000000000000000000000000000000000000000000",
+				"DestinationTag": 12345,
+				"SourceTag": 54321,
+				"OwnerNode": "0000000000000000",
+				"PreviousTxnID": "C4F71E9B01F5A78023E932ABF6B2C1F020986E6C9E55678FFBAE67A2F5B47468",
+				"LastLedgerSequence": 12345678,
+				"NetworkID": 1024,
+				"Memos": [
+					{
+					"Memo": {
+						"MemoType": "657363726F77",
+						"MemoData": "457363726F77206372656174656420666F72207061796D656E74"
+					}
+					}
+				],
+				"Signers": [
+					{
+					"Signer": {
+						"Account": "rSIGNER123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+						"SigningPubKey": "ED5F93AB1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12345678",
+						"TxnSignature": "3045022100D7F67A81F343...B87D"
+					}
+					}
+				],
+				"SigningPubKey": "ED5F93AB1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12345678",
+				"TxnSignature": "3045022100D7F67A81F343...B87D"
+			}`,
+			expectedTag:          func() *uint32 { v := uint32(12345); return &v }(),
+			expectUnmarshalError: false,
+		},
+		{
+			name: "pass - full EscrowCreate with IssuedAmount",
+			jsonData: `{
+				"TransactionType": "EscrowCreate",
+				"Account": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				"Destination": "rDEST123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				"Amount": {
+					"issuer": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+					"currency": "USD",
+					"value": "1000000"
+				},
+				"Fee": "10",
+				"Sequence": 1,
+				"Flags": 2147483648,
+				"CancelAfter": 695123456,
+				"FinishAfter": 695000000,
+				"Condition": "A0258020C4F71E9B01F5A78023E932ABF6B2C1F020986E6C9E55678FFBAE67A2F5B474680103080000000000000000000000000000000000000000000000000000000000000000",
+				"DestinationTag": 12345,
+				"SourceTag": 54321,
+				"OwnerNode": "0000000000000000",
+				"PreviousTxnID": "C4F71E9B01F5A78023E932ABF6B2C1F020986E6C9E55678FFBAE67A2F5B47468",
+				"LastLedgerSequence": 12345678,
+				"NetworkID": 1024,
+				"Memos": [
+					{
+					"Memo": {
+						"MemoType": "657363726F77",
+						"MemoData": "457363726F77206372656174656420666F72207061796D656E74"
+					}
+					}
+				],
+				"Signers": [
+					{
+					"Signer": {
+						"Account": "rSIGNER123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+						"SigningPubKey": "ED5F93AB1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12345678",
+						"TxnSignature": "3045022100D7F67A81F343...B87D"
+					}
+					}
+				],
+				"SigningPubKey": "ED5F93AB1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12345678",
+				"TxnSignature": "3045022100D7F67A81F343...B87D"
+			}`,
+			expectedTag:          func() *uint32 { v := uint32(12345); return &v }(),
+			expectUnmarshalError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/xrpl/transaction/escrow_finish.go
+++ b/xrpl/transaction/escrow_finish.go
@@ -49,7 +49,7 @@ func (e *EscrowFinish) Flatten() FlatTransaction {
 	flattened["TransactionType"] = "EscrowFinish"
 
 	if e.Owner != "" {
-		flattened["Owner"] = e.Owner
+		flattened["Owner"] = e.Owner.String()
 	}
 
 	if e.OfferSequence != 0 {

--- a/xrpl/transaction/flat_tx.go
+++ b/xrpl/transaction/flat_tx.go
@@ -22,12 +22,28 @@ func (f FlatTransaction) TxType() TxType {
 // Sequence returns the sequence number of the flattened transaction.
 func (f FlatTransaction) Sequence() uint32 {
 	sequence, ok := f["Sequence"].(json.Number)
-	if !ok {
-		return 0
+	if ok {
+		sequenceInt, err := sequence.Float64()
+		if err != nil {
+			return 0
+		}
+		return uint32(sequenceInt)
 	}
-	sequenceInt, err := sequence.Int64()
-	if err != nil {
-		return 0
+
+	// Handle float64 case (when JSON is parsed as float64 instead of json.Number)
+	if sequenceFloat, ok := f["Sequence"].(float64); ok {
+		return uint32(sequenceFloat)
 	}
-	return uint32(sequenceInt)
+
+	// Handle uint32 case (direct integer)
+	if sequenceInt, ok := f["Sequence"].(uint32); ok {
+		return sequenceInt
+	}
+
+	// Handle int case
+	if sequenceInt, ok := f["Sequence"].(int); ok {
+		return uint32(sequenceInt)
+	}
+
+	return 0
 }

--- a/xrpl/transaction/flat_tx.go
+++ b/xrpl/transaction/flat_tx.go
@@ -1,5 +1,9 @@
 package transaction
 
+import (
+	"encoding/json"
+)
+
 var _ Tx = (*FlatTransaction)(nil)
 
 // FlatTransaction is a flattened transaction represented as a map from field names to interface{} values.
@@ -13,4 +17,17 @@ func (f FlatTransaction) TxType() TxType {
 		return TxType("")
 	}
 	return TxType(txType)
+}
+
+// Sequence returns the sequence number of the flattened transaction.
+func (f FlatTransaction) Sequence() uint32 {
+	sequence, ok := f["Sequence"].(json.Number)
+	if !ok {
+		return 0
+	}
+	sequenceInt, err := sequence.Int64()
+	if err != nil {
+		return 0
+	}
+	return uint32(sequenceInt)
 }

--- a/xrpl/transaction/payment_channel_claim.go
+++ b/xrpl/transaction/payment_channel_claim.go
@@ -1,6 +1,8 @@
 package transaction
 
 import (
+	"encoding/json"
+
 	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
@@ -66,10 +68,10 @@ type PaymentChannelClaim struct {
 	CredentialIDs types.CredentialIDs `json:",omitempty"`
 	// (Optional) Total amount of XRP, in drops, delivered by this channel after processing this claim. Required to deliver XRP.
 	// Must be more than the total amount delivered by the channel so far, but not greater than the Amount of the signed claim. Must be provided except when closing the channel.
-	Balance types.XRPCurrencyAmount `json:",omitempty"`
-	// (Optional) The amount of XRP, in drops, authorized by the Signature. This must match the amount in the signed message.
-	// This is the cumulative amount of XRP that can be dispensed by the channel, including XRP previously redeemed.
-	Amount types.XRPCurrencyAmount `json:",omitempty"`
+	Balance types.CurrencyAmount `json:",omitempty"`
+	// The amount of XRP, in drops, or fungible tokens authorized by the Signature. This must match the amount in the signed message.
+	// This is the cumulative amount that can be dispensed by the channel, including funds previously redeemed. Non-XRP tokens can only be used if the TokenEscrow amendment is enabled.
+	Amount types.CurrencyAmount `json:",omitempty"`
 	// (Optional) The signature of this claim, as hexadecimal. The signed message contains the channel ID and the amount of the claim.
 	// Required unless the sender of the transaction is the source address of the channel.
 	Signature string `json:",omitempty"`
@@ -93,10 +95,10 @@ func (p *PaymentChannelClaim) Flatten() FlatTransaction {
 	if p.Channel != "" {
 		flattened["Channel"] = p.Channel.String()
 	}
-	if p.Balance != 0 {
+	if p.Balance != nil {
 		flattened["Balance"] = p.Balance.Flatten()
 	}
-	if p.Amount != 0 {
+	if p.Amount != nil {
 		flattened["Amount"] = p.Amount.Flatten()
 	}
 	if p.Signature != "" {
@@ -161,4 +163,39 @@ func (p *PaymentChannelClaim) Validate() (bool, error) {
 	}
 
 	return true, nil
+}
+
+// UnmarshalJSON unmarshals the PaymentChannelClaim transaction from JSON.
+func (p *PaymentChannelClaim) UnmarshalJSON(data []byte) error {
+	type paymentChannelClaimHelper struct {
+		BaseTx
+		Amount        json.RawMessage
+		Balance       json.RawMessage
+		Channel       types.Hash256
+		Signature     string
+		PublicKey     string
+		CredentialIDs types.CredentialIDs `json:",omitempty"`
+	}
+	var h paymentChannelClaimHelper
+	if err := json.Unmarshal(data, &h); err != nil {
+		return err
+	}
+	*p = PaymentChannelClaim{
+		BaseTx:        h.BaseTx,
+		Channel:       h.Channel,
+		Signature:     h.Signature,
+		PublicKey:     h.PublicKey,
+		CredentialIDs: h.CredentialIDs,
+	}
+	amount, err := types.UnmarshalCurrencyAmount(h.Amount)
+	if err != nil {
+		return err
+	}
+	p.Amount = amount
+	balance, err := types.UnmarshalCurrencyAmount(h.Balance)
+	if err != nil {
+		return err
+	}
+	p.Balance = balance
+	return nil
 }

--- a/xrpl/transaction/payment_channel_claim_test.go
+++ b/xrpl/transaction/payment_channel_claim_test.go
@@ -1,6 +1,8 @@
 package transaction
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/Peersyst/xrpl-go/xrpl/testutil"
@@ -74,7 +76,7 @@ func TestPaymentChannelClaim_Flatten(t *testing.T) {
 			}`,
 		},
 		{
-			name: "pass - PaymentChannelClaim with Balance and Amount",
+			name: "pass - PaymentChannelClaim with Balance and Amount as XRPCurrencyAmount",
 			claim: PaymentChannelClaim{
 				BaseTx: BaseTx{
 					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -88,6 +90,68 @@ func TestPaymentChannelClaim_Flatten(t *testing.T) {
 				"TransactionType": "PaymentChannelClaim",
 				"Balance": "1000",
 				"Amount": "2000"
+			}`,
+		},
+		{
+			name: "pass - PaymentChannelClaim with Balance and Amount as MPTCurrencyAmount",
+			claim: PaymentChannelClaim{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: PaymentChannelClaimTx,
+				},
+				Balance: types.MPTCurrencyAmount{
+					MPTIssuanceID: "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+					Value:         "1000",
+				},
+				Amount: types.MPTCurrencyAmount{
+					MPTIssuanceID: "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+					Value:         "2000",
+				},
+			},
+			expected: `{
+				"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"TransactionType": "PaymentChannelClaim",
+				"Balance": {
+					"mpt_issuance_id": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+					"value": "1000"
+				},
+				"Amount": {
+					"mpt_issuance_id": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+					"value": "2000"
+				}
+			}`,
+		},
+		{
+			name: "pass - PaymentChannelClaim with Balance and Amount as IssuedCurrencyAmount",
+			claim: PaymentChannelClaim{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: PaymentChannelClaimTx,
+				},
+				Balance: types.IssuedCurrencyAmount{
+					Issuer:   "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+					Currency: "USD",
+					Value:    "1000",
+				},
+				Amount: types.IssuedCurrencyAmount{
+					Issuer:   "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+					Currency: "USD",
+					Value:    "2000",
+				},
+			},
+			expected: `{
+				"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"TransactionType": "PaymentChannelClaim",
+				"Balance": {
+					"issuer": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+					"currency": "USD",
+					"value": "1000"
+				},
+				"Amount": {
+					"issuer": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+					"currency": "USD",
+					"value": "2000"
+				}
 			}`,
 		},
 		{
@@ -257,6 +321,171 @@ func TestPaymentChannelClaim_Validate(t *testing.T) {
 			if err != nil && err != tt.expectedErr {
 				t.Errorf("Validate() error = %v, expectedErr %v", err, tt.expectedErr)
 			}
+		})
+	}
+}
+
+func TestPaymentChannelClaim_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name                 string
+		jsonData             string
+		expectUnmarshalError bool
+	}{
+		{
+			name: "pass - full PaymentChannelClaim with IssuedCurrencyAmount",
+			jsonData: `{
+				"TransactionType": "PaymentChannelClaim",
+				"Account": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				"Channel": "ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC1",
+				"Amount": {
+					"issuer": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+					"currency": "USD",
+					"value": "1000000"
+				},
+				"Balance": {
+					"issuer": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+					"currency": "USD",
+					"value": "900000"
+				},
+				"CredentialIDs": ["1234567890abcdef", "1234567890abcdefg"],
+				"Fee": "10",
+				"Sequence": 1,
+				"Flags": 2147483648,
+				"CancelAfter": 695123456,
+				"FinishAfter": 695000000,
+				"Condition": "A0258020C4F71E9B01F5A78023E932ABF6B2C1F020986E6C9E55678FFBAE67A2F5B474680103080000000000000000000000000000000000000000000000000000000000000000",
+				"DestinationTag": 12345,
+				"SourceTag": 54321,
+				"OwnerNode": "0000000000000000",
+				"PreviousTxnID": "C4F71E9B01F5A78023E932ABF6B2C1F020986E6C9E55678FFBAE67A2F5B47468",
+				"LastLedgerSequence": 12345678,
+				"NetworkID": 1024,
+				"Memos": [
+					{
+					"Memo": {
+						"MemoType": "657363726F77",
+						"MemoData": "457363726F77206372656174656420666F72207061796D656E74"
+					}
+					}
+				],
+				"Signers": [
+					{
+					"Signer": {
+						"Account": "rSIGNER123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+						"SigningPubKey": "ED5F93AB1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12345678",
+						"TxnSignature": "3045022100D7F67A81F343...B87D"
+					}
+					}
+				],
+				"SigningPubKey": "ED5F93AB1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12345678",
+				"TxnSignature": "3045022100D7F67A81F343...B87D"
+			}`,
+			expectUnmarshalError: false,
+		},
+		{
+			name: "pass - full PaymentChannelClaim with MPTCurrencyAmount",
+			jsonData: `{
+				"TransactionType": "PaymentChannelClaim",
+				"Account": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				"Channel": "ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC1",
+				"Amount": {
+					"mpt_issuance_id": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+					"value": "1000000"
+				},
+				"Balance": {
+					"mpt_issuance_id": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+					"value": "900000"
+				},
+				"CredentialIDs": ["1234567890abcdef", "1234567890abcdefg"],
+				"Fee": "10",
+				"Sequence": 1,
+				"Flags": 2147483648,
+				"CancelAfter": 695123456,
+				"FinishAfter": 695000000,
+				"Condition": "A0258020C4F71E9B01F5A78023E932ABF6B2C1F020986E6C9E55678FFBAE67A2F5B474680103080000000000000000000000000000000000000000000000000000000000000000",
+				"DestinationTag": 12345,
+				"SourceTag": 54321,
+				"OwnerNode": "0000000000000000",
+				"PreviousTxnID": "C4F71E9B01F5A78023E932ABF6B2C1F020986E6C9E55678FFBAE67A2F5B47468",
+				"LastLedgerSequence": 12345678,
+				"NetworkID": 1024,
+				"Memos": [
+					{
+					"Memo": {
+						"MemoType": "657363726F77",
+						"MemoData": "457363726F77206372656174656420666F72207061796D656E74"
+					}
+					}
+				],
+				"Signers": [
+					{
+					"Signer": {
+						"Account": "rSIGNER123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+						"SigningPubKey": "ED5F93AB1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12345678",
+						"TxnSignature": "3045022100D7F67A81F343...B87D"
+					}
+					}
+				],
+				"SigningPubKey": "ED5F93AB1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12345678",
+				"TxnSignature": "3045022100D7F67A81F343...B87D"
+			}`,
+			expectUnmarshalError: false,
+		},
+		{
+			name: "pass - full PaymentChannelClaim with XRPCurrencyAmount",
+			jsonData: `{
+				"TransactionType": "PaymentChannelClaim",
+				"Account": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				"Channel": "ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC1",
+				"Amount": "1000000",
+				"Balance": "30000",
+				"CredentialIDs": ["1234567890abcdef", "1234567890abcdefg"],
+				"Fee": "10",
+				"Sequence": 1,
+				"Flags": 2147483648,
+				"CancelAfter": 695123456,
+				"FinishAfter": 695000000,
+				"Condition": "A0258020C4F71E9B01F5A78023E932ABF6B2C1F020986E6C9E55678FFBAE67A2F5B474680103080000000000000000000000000000000000000000000000000000000000000000",
+				"DestinationTag": 12345,
+				"SourceTag": 54321,
+				"OwnerNode": "0000000000000000",
+				"PreviousTxnID": "C4F71E9B01F5A78023E932ABF6B2C1F020986E6C9E55678FFBAE67A2F5B47468",
+				"LastLedgerSequence": 12345678,
+				"NetworkID": 1024,
+				"Memos": [
+					{
+					"Memo": {
+						"MemoType": "657363726F77",
+						"MemoData": "457363726F77206372656174656420666F72207061796D656E74"
+					}
+					}
+				],
+				"Signers": [
+					{
+					"Signer": {
+						"Account": "rSIGNER123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+						"SigningPubKey": "ED5F93AB1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12345678",
+						"TxnSignature": "3045022100D7F67A81F343...B87D"
+					}
+					}
+				],
+				"SigningPubKey": "ED5F93AB1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12345678",
+				"TxnSignature": "3045022100D7F67A81F343...B87D"
+			}`,
+			expectUnmarshalError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var paymentChannelCreate PaymentChannelClaim
+			err := json.Unmarshal([]byte(tt.jsonData), &paymentChannelCreate)
+			fmt.Println(paymentChannelCreate.TransactionType)
+			if (err != nil) != tt.expectUnmarshalError {
+				t.Errorf("Unmarshal() error = %v, expectUnmarshalError %v", err, tt.expectUnmarshalError)
+				return
+			}
+
 		})
 	}
 }

--- a/xrpl/transaction/payment_channel_create.go
+++ b/xrpl/transaction/payment_channel_create.go
@@ -72,6 +72,7 @@ func (p *PaymentChannelCreate) Flatten() FlatTransaction {
 	return flattened
 }
 
+// UnmarshalJSON unmarshals the PaymentChannelCreate transaction from JSON.
 func (p *PaymentChannelCreate) UnmarshalJSON(data []byte) error {
 	type paymentChannelCreateHelper struct {
 		BaseTx

--- a/xrpl/transaction/payment_channel_create_test.go
+++ b/xrpl/transaction/payment_channel_create_test.go
@@ -260,6 +260,97 @@ func TestPaymentChannelCreate_Unmarshal(t *testing.T) {
 			expectUnmarshalError: false,
 		},
 		{
+			name: "pass - full PaymentChannelCreate with IssuedCurrencyAmount",
+			jsonData: `{
+				"TransactionType": "PaymentChannelCreate",
+				"Account": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				"Destination": "rDEST123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				"Amount": {
+					"issuer": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+					"currency": "USD",
+					"value": "1000000"
+				},
+				"Fee": "10",
+				"Sequence": 1,
+				"Flags": 2147483648,
+				"CancelAfter": 695123456,
+				"FinishAfter": 695000000,
+				"Condition": "A0258020C4F71E9B01F5A78023E932ABF6B2C1F020986E6C9E55678FFBAE67A2F5B474680103080000000000000000000000000000000000000000000000000000000000000000",
+				"DestinationTag": 12345,
+				"SourceTag": 54321,
+				"OwnerNode": "0000000000000000",
+				"PreviousTxnID": "C4F71E9B01F5A78023E932ABF6B2C1F020986E6C9E55678FFBAE67A2F5B47468",
+				"LastLedgerSequence": 12345678,
+				"NetworkID": 1024,
+				"Memos": [
+					{
+					"Memo": {
+						"MemoType": "657363726F77",
+						"MemoData": "457363726F77206372656174656420666F72207061796D656E74"
+					}
+					}
+				],
+				"Signers": [
+					{
+					"Signer": {
+						"Account": "rSIGNER123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+						"SigningPubKey": "ED5F93AB1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12345678",
+						"TxnSignature": "3045022100D7F67A81F343...B87D"
+					}
+					}
+				],
+				"SigningPubKey": "ED5F93AB1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12345678",
+				"TxnSignature": "3045022100D7F67A81F343...B87D"
+			}`,
+			expectedTag:          func() *uint32 { v := uint32(12345); return &v }(),
+			expectUnmarshalError: false,
+		},
+		{
+			name: "pass - full PaymentChannelCreate with MPTCurrencyAmount",
+			jsonData: `{
+				"TransactionType": "PaymentChannelCreate",
+				"Account": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				"Destination": "rDEST123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				"Amount": {
+					"mpt_issuance_id": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+					"value": "1000000"
+				},
+				"Fee": "10",
+				"Sequence": 1,
+				"Flags": 2147483648,
+				"CancelAfter": 695123456,
+				"FinishAfter": 695000000,
+				"Condition": "A0258020C4F71E9B01F5A78023E932ABF6B2C1F020986E6C9E55678FFBAE67A2F5B474680103080000000000000000000000000000000000000000000000000000000000000000",
+				"DestinationTag": 12345,
+				"SourceTag": 54321,
+				"OwnerNode": "0000000000000000",
+				"PreviousTxnID": "C4F71E9B01F5A78023E932ABF6B2C1F020986E6C9E55678FFBAE67A2F5B47468",
+				"LastLedgerSequence": 12345678,
+				"NetworkID": 1024,
+				"Memos": [
+					{
+					"Memo": {
+						"MemoType": "657363726F77",
+						"MemoData": "457363726F77206372656174656420666F72207061796D656E74"
+					}
+					}
+				],
+				"Signers": [
+					{
+					"Signer": {
+						"Account": "rSIGNER123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+						"SigningPubKey": "ED5F93AB1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12345678",
+						"TxnSignature": "3045022100D7F67A81F343...B87D"
+					}
+					}
+				],
+				"SigningPubKey": "ED5F93AB1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12345678",
+				"TxnSignature": "3045022100D7F67A81F343...B87D"
+			}`,
+			expectedTag:          func() *uint32 { v := uint32(12345); return &v }(),
+			expectUnmarshalError: false,
+		},
+		{
 			name: "pass - partial PaymentChannelCreate with DestinationTag set to 0",
 			jsonData: `{
 				"TransactionType": "PaymentChannelCreate",

--- a/xrpl/transaction/payment_channel_create_test.go
+++ b/xrpl/transaction/payment_channel_create_test.go
@@ -93,6 +93,62 @@ func TestPaymentChannelCreate_Flatten(t *testing.T) {
 				"PublicKey":   "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A"
 			}`,
 		},
+		{
+			name: "pass - Optional fields omitted and Amount as IssuedCurrencyAmount",
+			tx: &PaymentChannelCreate{
+				BaseTx: BaseTx{
+					Account:         "r2UeJh4HhYc5VtYc8U2YpZfQzY5Lw8kZV",
+					TransactionType: PaymentChannelCreateTx,
+				},
+				Amount: types.IssuedCurrencyAmount{
+					Currency: "USD",
+					Value:    "10000",
+					Issuer:   "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				},
+				Destination: types.Address("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"),
+				SettleDelay: 86400,
+				PublicKey:   "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
+			},
+			expected: `{
+				"Account":     "r2UeJh4HhYc5VtYc8U2YpZfQzY5Lw8kZV",
+				"TransactionType": "PaymentChannelCreate",
+				"Amount": {
+					"issuer": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+					"currency": "USD",
+					"value": "10000"
+				},
+				"Destination": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"SettleDelay": 86400,
+				"PublicKey":   "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A"
+			}`,
+		},
+		{
+			name: "pass - Optional fields omitted and Amount as MPTCurrencyAmount",
+			tx: &PaymentChannelCreate{
+				BaseTx: BaseTx{
+					Account:         "r2UeJh4HhYc5VtYc8U2YpZfQzY5Lw8kZV",
+					TransactionType: PaymentChannelCreateTx,
+				},
+				Amount: types.MPTCurrencyAmount{
+					MPTIssuanceID: "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+					Value:         "10000",
+				},
+				Destination: types.Address("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"),
+				SettleDelay: 86400,
+				PublicKey:   "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
+			},
+			expected: `{
+				"Account":     "r2UeJh4HhYc5VtYc8U2YpZfQzY5Lw8kZV",
+				"TransactionType": "PaymentChannelCreate",
+				"Amount": {
+					"mpt_issuance_id": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+					"value": "10000"
+				},
+				"Destination": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"SettleDelay": 86400,
+				"PublicKey":   "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A"
+			}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/xrpl/transaction/payment_channel_fund_test.go
+++ b/xrpl/transaction/payment_channel_fund_test.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -54,6 +55,58 @@ func TestPaymentChannelFund_Flatten(t *testing.T) {
 				"TransactionType": "PaymentChannelFund",
 				"Channel": "DEF456",
 				"Amount": "300000",
+				"Expiration": 543171558
+			}`,
+		},
+		{
+			name: "pass - with Expiration and Amount as MPTCurrencyAmount",
+			tx: &PaymentChannelFund{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: PaymentChannelFundTx,
+				},
+				Channel: "DEF456",
+				Amount: types.MPTCurrencyAmount{
+					MPTIssuanceID: "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+					Value:         "300000",
+				},
+				Expiration: 543171558,
+			},
+			expected: `{
+				"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"TransactionType": "PaymentChannelFund",
+				"Channel": "DEF456",
+				"Amount": {
+					"mpt_issuance_id": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+					"value": "300000"
+				},
+				"Expiration": 543171558
+			}`,
+		},
+		{
+			name: "pass - with Expiration and Amount as IssuedCurrencyAmount",
+			tx: &PaymentChannelFund{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: PaymentChannelFundTx,
+				},
+				Channel: "DEF456",
+				Amount: types.IssuedCurrencyAmount{
+					Issuer:   "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+					Currency: "USD",
+					Value:    "300000",
+				},
+				Expiration: 543171558,
+			},
+			expected: `{
+				"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"TransactionType": "PaymentChannelFund",
+				"Channel": "DEF456",
+				"Amount": {
+					"issuer": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+					"currency": "USD",
+					"value": "300000"
+				},
 				"Expiration": 543171558
 			}`,
 		},
@@ -141,6 +194,60 @@ func TestPaymentChannelFund_Validate(t *testing.T) {
 				return
 			}
 			assert.Equal(t, tt.wantErr, err != nil)
+		})
+	}
+}
+
+func TestPaymentChannelFund_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name                 string
+		jsonData             string
+		expectUnmarshalError bool
+	}{
+		{
+			name: "pass - full PaymentChannelFund with MPTCurrencyAmount",
+			jsonData: `{
+				"TransactionType": "PaymentChannelFund",
+				"Account": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				"Channel": "DEF456",
+				"Amount": {
+					"mpt_issuance_id": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+					"value": "300000"
+				},
+				"Expiration": 543171558
+			}`,
+		},
+		{
+			name: "pass - full PaymentChannelFund with IssuedCurrencyAmount",
+			jsonData: `{
+				"TransactionType": "PaymentChannelFund",
+				"Account": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				"Channel": "DEF456",
+				"Amount": {
+					"issuer": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+					"currency": "USD",
+					"value": "300000"
+				},
+				"Expiration": 543171558
+			}`,
+		},
+		{
+			name: "pass - full PaymentChannelFund with XRPCurrencyAmount",
+			jsonData: `{
+				"TransactionType": "PaymentChannelFund",
+				"Account": "rEXAMPLE123456789ABCDEFGHJKLMNPQRSTUVWXYZ",
+				"Channel": "DEF456",
+				"Amount": "300000",
+				"Expiration": 543171558
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var paymentChannelFund PaymentChannelFund
+			err := json.Unmarshal([]byte(tt.jsonData), &paymentChannelFund)
+			assert.Equal(t, tt.expectUnmarshalError, err != nil)
 		})
 	}
 }


### PR DESCRIPTION
# Title

## Description
This PR aims to:

- Add support for the `TokenEscrow` amendment (XLS-85).
- Fix the `Flatten` function for the `Destination` and `Owner` fields in the Escrow transaction types.
- Adds example of the TokenEscrow with an IOU.
- Adds a method to get the `Sequence` from the `TxResponse` which makes parsing easier for Escrows than `response["Sequence"]`.

## Type of change
- [X] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective
- [X] New and existing unit tests pass locally with my changes

## Changes

See description

## Notes (optional)

Examples working:

<img width="696" height="701" alt="Screenshot 2025-09-26 at 22 17 41" src="https://github.com/user-attachments/assets/6aacd03e-7ded-49f6-a9cc-6f505faba31c" />

