### PR TITLE
chore(skills): automate XRPL-Standards reference sync

### DIFF
--- a/.agents/skills/xrpl-standards/SKILL.md
+++ b/.agents/skills/xrpl-standards/SKILL.md
@@ -167,7 +167,17 @@ bash <skill-dir>/scripts/fetch-xls.sh <number>
 
 ## Refreshing Refs
 
+Use the local sync script in this repo:
+
 ```bash
-cd packages/skills-build
-pnpm build:xrpl-standards
+python3 .agents/skills/xrpl-standards/scripts/sync-xls-standards.py
 ```
+
+Run with `--dry-run` to inspect changes without writing files.
+
+- `--extract` writes the compressed extracted summary.
+- Default writes full upstream `README.md` content.
+
+A GitHub Action also runs this script every Monday and Thursday at 06:00 UTC:
+
+- `.github/workflows/sync-xrpl-standards.yml`

--- a/.agents/skills/xrpl-standards/references/INDEX.md
+++ b/.agents/skills/xrpl-standards/references/INDEX.md
@@ -1,7 +1,6 @@
 # XRPL Standards Index
 
 ## identity
-
 | XLS | Title | Status | File |
 | ----- | ------- | -------- | ------ |
 | 40 | Decentralized Identity on XRP Ledger | Final | `references/identity/xls-0040.md` |
@@ -9,7 +8,6 @@
 | 70 | On-Chain Credentials | Final | `references/identity/xls-0070.md` |
 
 ## tokens
-
 | XLS | Title | Status | File |
 | ----- | ------- | -------- | ------ |
 | 10 | Non-Transferable Token (NTT) standard | Stagnant | `references/tokens/xls-0010.md` |
@@ -30,7 +28,6 @@
 | 96 | Confidential Transfers for Multi-Purpose Tokens | Draft | `references/tokens/xls-0096.md` |
 
 ## defi
-
 | XLS | Title | Status | File |
 | ----- | ------- | -------- | ------ |
 | 30 | Automated Market Maker on XRPL | Final | `references/defi/xls-0030.md` |
@@ -44,7 +41,6 @@
 | 98 | Standard Metadata for Vaults | Draft | `references/defi/xls-0098.md` |
 
 ## payments
-
 | XLS | Title | Status | File |
 | ----- | ------- | -------- | ------ |
 | 34 | Token-Enabled Escrows and Payment Channels | Withdrawn | `references/payments/xls-0034.md` |
@@ -56,7 +52,6 @@
 | 100 | Smart Escrows | Draft | `references/payments/xls-0100.md` |
 
 ## accounts
-
 | XLS | Title | Status | File |
 | ----- | ------- | -------- | ------ |
 | 7 | Deletable Accounts | Final | `references/accounts/xls-0007.md` |
@@ -73,21 +68,18 @@
 | 86 | Firewall | Draft | `references/accounts/xls-0086.md` |
 
 ## data
-
 | XLS | Title | Status | File |
-|-----|-------|--------|------|
+| ----- | ------- | -------- | ------ |
 | 47 | Price Oracles on XRP Ledger | Final | `references/data/xls-0047.md` |
 | 78 | Subscriptions | Draft | `references/data/xls-0078.md` |
 
 ## cross-chain
-
 | XLS | Title | Status | File |
-|-----|-------|--------|------|
+| ----- | ------- | -------- | ------ |
 | 38 | Cross-Chain Bridge | Final | `references/cross-chain/xls-0038.md` |
 | 41 | XRPL Proof of Payment Standard (XPOP) | Final | `references/cross-chain/xls-0041.md` |
 
 ## smart-contracts
-
 | XLS | Title | Status | File |
 | ----- | ------- | -------- | ------ |
 | 42 | XRPL Plugins | Stagnant | `references/smart-contracts/xls-0042.md` |
@@ -95,7 +87,6 @@
 | 102 | WASM VM | Draft | `references/smart-contracts/xls-0102.md` |
 
 ## core
-
 | XLS | Title | Status | File |
 | ----- | ------- | -------- | ------ |
 | 1 | XLS Process and Guidelines | Living | `references/core/xls-0001.md` |
@@ -120,7 +111,6 @@
 | 97 | Formats, Fields and Flags | Final | `references/core/xls-0097.md` |
 
 ## ecosystem
-
 | XLS | Title | Status | File |
 | ----- | ------- | -------- | ------ |
 | 2 | XRPL destination information | Stagnant | `references/ecosystem/xls-0002.md` |

--- a/.agents/skills/xrpl-standards/references/payments/xls-0056.md
+++ b/.agents/skills/xrpl-standards/references/payments/xls-0056.md
@@ -7,7 +7,7 @@
   status: Final
   category: Amendment
   created: 2023-12-13
-  updated: 2026-02-10
+  updated: 2026-08-14
 </pre>
 
 # Atomic/Batch Transactions
@@ -31,7 +31,7 @@ Some use-cases that may be enabled by batch transactions include (but are certai
 
 ## 1. Overview
 
-This spec adds one new transaction: `Batch`. It also adds an addition to the common fields of all transactions. It will not require any new ledger objects, nor modifications to existing ledger objects. It will require an amendment, tentatively titled `featureBatch`.
+This spec adds one new transaction: `Batch`. It also adds an addition to the common fields of all transactions. It will not require any new ledger objects, nor modifications to existing ledger objects. It will require an amendment.
 
 The rough idea of this design is that users can include "sub-transactions" inside `Batch`, and these transactions are processed atomically. The design also supports transactions from different accounts in the same `Batch` wrapper transaction.
 
@@ -98,7 +98,9 @@ _Note: the 8 transaction limit can be relaxed in the future._
 
 This field operates similarly to [multi-signing](https://xrpl.org/docs/concepts/accounts/multi-signing/) on the XRPL. It is only needed if multiple accounts' transactions are included in the `Batch` transaction; otherwise, the normal transaction signature provides the same security guarantees.
 
-This field must be provided if more than one account has inner transactions included in the `Batch`. In that case, this field must contain signatures from all accounts whose inner transactions are included, excluding the account signing the outer transaction (if applicable).
+This field must be provided if any account other than the account signing the outer transaction is required to authorize an inner transaction. In that case, this field must contain a signature from every such account, excluding the account signing the outer transaction (if applicable). The set of required signers is exactly the set of accounts that would ordinarily have to sign the inner transactions (see [section 2.1.3.1](#2131-account)), and the `BatchSigners` array must match that set exactly — no missing entries, and no extra entries.
+
+The entries in `BatchSigners` **must be sorted in strictly ascending order by `Account`**. Duplicate entries are not permitted.
 
 Each object in this array contains the following fields:
 
@@ -113,15 +115,35 @@ Either the `SigningPubKey` and `TxnSignature` fields must be included, or the `S
 
 ##### 2.1.3.1. `Account`
 
-This is an account that has at least one inner transaction.
+This is an account that would ordinarily have to sign at least one of the inner transactions. This includes the account that submits an inner transaction, the delegate that signs a delegated inner transaction (in which case the delegate, not the account holder, is the required signer), and any other account whose signature the inner transaction would normally require (e.g. a co-signer).
 
-##### 2.1.3.2. `SigningPubKey` and `TxnSignature`
+Since a single inner transaction can require more than one signer, the number of entries in `BatchSigners` is not bounded by the number of inner transactions.
 
-These fields are included if the account is signing with a single signature (as opposed to multi-sign). They sign the `Flags` field and the hashes of the transactions in `RawTransactions`.
+##### 2.1.3.2. Signing Payload
 
-##### 2.1.3.3. `Signers`
+The data signed by a `BatchSigner` (whether single-sign or multi-sign) is the serialization of:
 
-This field is included if the account is signing with multi-sign (as opposed to a single signature). It operates equivalently to the [`Signers` field](https://xrpl.org/docs/references/protocol/transactions/common-fields/#signers-field) used in standard transaction multi-sign. This field holds the signatures for the `Flags` field and the hashes of the transactions in `RawTransactions`.
+1. `HashPrefix::Batch` (the 4-byte `BCH\0` hash prefix)
+2. The outer transaction's `Account` (the 160-bit AccountID)
+3. The outer transaction's sequence value (`Sequence`, or `TicketSequence` if `Sequence` is 0), as a `UInt32`
+4. The outer transaction's `Flags`, as a `UInt32`
+5. The number of inner transactions in `RawTransactions`, as a `UInt32`
+6. The transaction ID (hash) of each inner transaction in `RawTransactions`, in order
+
+Followed by the signer-specific suffix:
+
+- **Single-sign** (`SigningPubKey` + `TxnSignature`): the `BatchSigner`'s `Account` is appended to the payload above before signing.
+- **Multi-sign** (`Signers`): the `BatchSigner`'s `Account` is appended, and then for each individual signer within the `Signers` array, that signer's `Account` is appended (via the standard `finishMultiSigningData` suffix) before signing.
+
+Binding the outer `Account` and outer sequence into the signed payload prevents a signed `BatchSigners` entry from being replayed against a different outer transaction.
+
+##### 2.1.3.3. `SigningPubKey` and `TxnSignature`
+
+These fields are included if the account is signing with a single signature (as opposed to multi-sign).
+
+##### 2.1.3.4. `Signers`
+
+This field is included if the account is signing with multi-sign (as opposed to a single signature). It operates equivalently to the [`Signers` field](https://xrpl.org/docs/references/protocol/transactions/common-fields/#signers-field) used in standard transaction multi-sign.
 
 ### 2.2. Transaction Fee
 
@@ -141,34 +163,36 @@ The standard transaction failure conditions still apply here.
 1. The `Flags` field is not set to exactly one of the supported batch modes (`temINVALID_FLAG`).
 1. Inner transactions
    1. There are fewer than 2 transactions in the `RawTransactions` field (`temARRAY_EMPTY`).
-   2. There are more than 8 transactions in the `RawTransactions` field (`temARRAY_TOO_LARGE`).
+   2. There are more than 8 transactions in the `RawTransactions` field. The `Batch` fails to deserialize, so it is rejected as malformed before preflight and no result code is returned.
    3. The `RawTransactions` field contains a transaction that is not a valid transaction.
    4. One of the inner transactions has a `Fee` greater than 0 (`temBAD_FEE`).
    5. One of the inner transactions has a `TxnSignature` field included (`temBAD_SIGNATURE`).
    6. One of the inner transactions has a non-empty `SigningPubKey` (`temBAD_REGKEY`).
    7. One of the inner transactions is has a `Signers` field included (`temBAD_SIGNER`).
-   8. One of the inner transactions has `TransactionType` of `Batch` (`temINVALID`).
+   8. One of the inner transactions has `TransactionType` of `Batch`. As above, the `Batch` fails to deserialize and is rejected as malformed before preflight.
    9. One of the inner transactions has a different invalid `TransactionType` (`temINVALID_INNER_BATCH`).
    10. There is a duplicate transaction in the `RawTransactions` field (`temREDUNDANT`).
    11. One of the inner transactions does not have the `tfInnerBatchTxn` flag set (`temINVALID_FLAG`).
    12. One of the inner transactions fails its preflight checks (i.e. is invalid, irrespective of ledger state) (`temINVALID_INNER_BATCH`).
-   13. Either both or neither of `TicketSequence` and `Sequence` are set (`temSEQ_AND_TICKET`).
+   13. One of the inner transactions has `TicketSequence` set and a non-zero `Sequence`, or has no `TicketSequence` and a `Sequence` of 0 (`temSEQ_AND_TICKET`). In other words, exactly one of the two must be used: a ticketed inner transaction sets `TicketSequence` and `Sequence: 0`, and a sequence-based inner transaction sets a non-zero `Sequence` and omits `TicketSequence`.
 1. `BatchSigners`
-   1. The length of `BatchSigners` is greater than the number of transactions in `RawTransactions` (`temARRAY_TOO_LARGE`).
+   1. The length of `BatchSigners` is greater than 24 (`temARRAY_TOO_LARGE`). This is three times the maximum number of inner transactions, since a single inner transaction can require up to three distinct signers.
    2. The `BatchSigners` field contains a signature from the account signing the outer transaction (`temBAD_SIGNER`).
-   3. The `BatchSigners` field contains a duplicate signature (`temREDUNDANT`).
-   4. The `BatchSigners` field contains a signature from an account that does not have any inner transactions (`temBAD_SIGNER`).
-   5. The `BatchSigners` field is missing a signature from an account that has inner transactions (`temBAD_SIGNER`).
-   6. The `BatchSigners` field contains an invalid signature (`temBAD_SIGNATURE`).
+   3. The `BatchSigners` field contains a duplicate signer (`temBAD_SIGNER`).
+   4. The `BatchSigners` field is not sorted in strictly ascending order by `Account` (`temBAD_SIGNER`).
+   5. The `BatchSigners` field contains a signature from an account that is not a required signer of any inner transaction (`temBAD_SIGNER`).
+   6. The `BatchSigners` field is missing a signature from an account that is a required signer of an inner transaction (`temBAD_SIGNER`). This includes the case where the `BatchSigners` field is required but is not present at all.
+   7. The `BatchSigners` field contains an invalid signature (`temINVALID`). Batch signer signatures are verified as part of standard transaction signature checking, alongside the outer transaction's own signature, so a bad batch signature surfaces the same way any bad signature does.
 1. Preclaim/doApply errors
    1. The public key for a signer is not a valid public key (`tefBAD_AUTH`). (This should be caught by preflight checks, but it is an additional backup check just in case).
-   2. The batch signer is single-signing:
-      1. The public key for a signer is not valid for the account ('`tefBAD_AUTH`).
+   2. A `BatchSigners` entry references a [pseudo-account](https://xrpl.org/docs/concepts/accounts/pseudo-accounts) (`tefBAD_AUTH`). Pseudo-accounts cannot sign batch entries.
+   3. The batch signer is single-signing:
+      1. The public key for a signer is not valid for the account (`tefBAD_AUTH`).
       2. The account is signing with the account's master key, but the master key is disabled (`tefMASTER_DISABLED`).
-   3. The batch signer is multi-signing:
+   4. The batch signer is multi-signing:
       1. The account does not have a signer list (`tefNOT_MULTI_SIGNING`).
       2. The signing account is not a signer on the signer list (`tefBAD_SIGNATURE`).
-      3. The `SigningPubkey` field in a `SignerEntry` field is empty or not a valid public key (`tefBAD_SIGNATURE`).
+      3. The `SigningPubKey` field in a `SignerEntry` field is empty or not a valid public key (`tefBAD_SIGNATURE`).
       4. The signing account is signing with the account's master key, but the master key is disabled (`tefMASTER_DISABLED`).
       5. The `SigningPubKey` field is not the `Account`'s master or regular key (`tefBAD_SIGNATURE`).
       6. There is not enough signing weight to meet the `SignerQuorum` (`tefBAD_QUORUM`).
@@ -503,13 +527,35 @@ Note that the inner transactions are committed as normal transactions.
 
 ## 3. Transaction Common Fields
 
-This standard doesn't add any new field to the [transaction common fields](https://xrpl.org/docs/references/protocol/transactions/common-fields/), but it does add another global transaction flag:
+### 3.1. Flags
+
+This standard adds another global transaction flag:
 
 | Flag Name         | Value        |
 | ----------------- | ------------ |
 | `tfInnerBatchTxn` | `0x40000000` |
 
 This flag should only be used if a transaction is an inner transaction in a `Batch` transaction. This signifies that the transaction shouldn't be signed. Any normal transaction that includes this flag should be rejected.
+
+### 3.2. Transaction Fee
+
+Any transaction with `tfInnerBatchTxn` should have a `Fee` of `0` (the fee will be paid as a part of the outer `Batch` transaction).
+
+### 3.3. Failure Conditions
+
+#### 3.3.1. Data Verification
+
+- A transaction with `tfInnerBatchTxn`:
+  - Is not in a `Batch` transaction (`temINVALID_INNER_BATCH`).
+  - Has a non-zero or non-XRP `Fee` (`temBAD_FEE`).
+  - Has a `TxnSignature` field included (`temBAD_SIGNATURE`).
+  - Has a non-empty `SigningPubKey` (`temBAD_REGKEY`).
+  - Has a `Signers` field included (`temBAD_SIGNER`).
+  - `TicketSequence` is set and `Sequence` is non-zero, or `TicketSequence` is not set and `Sequence` is 0 (`temSEQ_AND_TICKET`).
+
+A standalone (non-batch) transaction that sets `tfInnerBatchTxn` is rejected. This prevents an attacker from submitting an unsigned inner transaction directly. A transaction applied via the batch path that does not set `tfInnerBatchTxn` is also rejected (this should not occur in practice; it indicates a programming error).
+
+In addition, each inner transaction must pass its own local checks (`passesLocalChecks`) as part of the outer `Batch`'s local checks at submit and relay time. A `Batch` whose inner transaction fails them is rejected before it reaches the transaction engine, so no result code is returned.
 
 ## 4. Rationale
 

--- a/.agents/skills/xrpl-standards/references/tokens/xls-0096.md
+++ b/.agents/skills/xrpl-standards/references/tokens/xls-0096.md
@@ -141,29 +141,14 @@ To support confidential MPTs, the existing `MPTokenIssuance` ledger object is ex
 
 ### 6.2. Flags
 
-Two new flags are introduced for the `MPTokenIssuance` ledger object. Note that **`lsfMPTCanHoldConfidentialBalance`** is stored in the standard `sfFlags` field, while **`lsmfMPTCannotEnableCanHoldConfidentialBalance`** is stored in the `sfMutableFlags` field.
+Two new flags are introduced for the `MPTokenIssuance` ledger object. Note that **`lsfMPTCanHoldConfidentialBalance`** is stored in the standard `sfFlags` field, while **`lsifMPTCanHoldConfidentialBalance`** is stored in the `sfImmutableFlags` field.
 
-| Flag Name                                       | Field            | Hex Value    | Description                                                                                         |
-| :---------------------------------------------- | :--------------- | :----------- | :-------------------------------------------------------------------------------------------------- |
-| `lsfMPTCanHoldConfidentialBalance`              | `sfFlags`        | `0x00000080` | Indicates that confidential transfers are enabled for this token issuance.                          |
-| `lsmfMPTCannotEnableCanHoldConfidentialBalance` | `sfMutableFlags` | `0x00000080` | If set, the `lsfMPTCanHoldConfidentialBalance` flag can never be changed after the token is issued. |
+| Flag Name                           | Field              | Hex Value    | Description                                                                                         |
+| :---------------------------------- | :----------------- | :----------- | :-------------------------------------------------------------------------------------------------- |
+| `lsfMPTCanHoldConfidentialBalance`  | `sfFlags`          | `0x00000080` | Indicates that confidential transfers are enabled for this token issuance.                          |
+| `lsifMPTCanHoldConfidentialBalance` | `sfImmutableFlags` | `0x00000080` | If set, the `lsfMPTCanHoldConfidentialBalance` flag can never be changed after the token is issued. |
 
-**Note**: `sfMutableFlags` is introduced in the amendment [`DynamicMPT`](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0094-dynamic-MPT). To use this field,the `DynamicMPT` amendment must be enabled.
-
-### 6.2.1. Prerequisite: Enabling Freeze and Clawback for Confidential Funds
-
-The ability to freeze (lock) a holder's confidential balance and to perform `ConfidentialMPTClawback` depends on the `lsfMPTCanLock` and `lsfMPTCanClawback` flags respectively. These flags are governed by XLS-94 (`DynamicMPT`) mutable flags.
-
-**`lsmfMPTCanMutateCanLock` defaults to `false`**. Unless the issuer explicitly opts in at issuance time, the `lsfMPTCanLock` flag cannot be set or cleared after creation, meaning confidential balances cannot be frozen.
-
-To enable freeze and clawback of confidential funds, the issuer **must** set `tmfMPTCanMutateCanLock` (and, for clawback, `tmfMPTCanMutateCanClawback`) in the `MutableFlags` field of the `MPTokenIssuanceCreate` transaction. Once set, the issuer may later use `MPTokenIssuanceSet` with `tmfMPTSetCanLock` / `tmfMPTSetCanClawback` to activate those controls.
-
-| `MutableFlags` bit (creation) | On-ledger flag                | Effect when later set via `MPTokenIssuanceSet`                             |
-| :---------------------------- | :---------------------------- | :------------------------------------------------------------------------- |
-| `tmfMPTCanMutateCanLock`      | `lsmfMPTCanMutateCanLock`     | Allows issuer to freeze/unfreeze individual or global balances.            |
-| `tmfMPTCanMutateCanClawback`  | `lsmfMPTCanMutateCanClawback` | Allows issuer to enable `lsfMPTCanClawback` for `ConfidentialMPTClawback`. |
-
-If `lsmfMPTCanMutateCanLock` is **not** set, any attempt to freeze a confidential balance or perform `ConfidentialMPTClawback` will fail with `tecNO_PERMISSION`.
+**Note**: `sfImmutableFlags` is introduced in the amendment [`DynamicMPT`](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0094-dynamic-MPT). To use this field,the `DynamicMPT` amendment must be enabled.
 
 ### 6.3. Managing Confidentiality Settings
 
@@ -174,21 +159,21 @@ The `lsfMPTCanHoldConfidentialBalance` flag enables the use of confidential tran
 > **Note on Terminology:**
 
 - `sfFlags`: The prefix `lsf` refers to ledger state flags, while `tf` refers to the transaction flags.
-- `sfMutableFlags`: The prefix `lsmf` refers to the mutable ledger state flags, while `tmf` refers to the transaction mutable flags.
+- `sfImmutableFlags`: The prefix `lsif` refers to the immutable ledger state flags.
 
-- **Default Behavior (Mutable):** By default, without setting `tmfMPTCannotEnableCanHoldConfidentialBalance`, the issuer retains the ability to enable the confidential amount setting (`lsfMPTCanHoldConfidentialBalance`) via [`MPTokenIssuanceSet`](https://xrpl.org/docs/references/protocol/transactions/types/mptokenissuanceset) transactions. Enabling is one-way; the flag cannot be cleared once set.
-- **Permanent Lock (Immutable):** If the issuer sets the mutable flag `tmfMPTCannotEnableCanHoldConfidentialBalance` through [`MPTokenIssuanceCreate`](https://xrpl.org/docs/references/protocol/transactions/types/mptokenissuancecreate) transaction, the `lsfMPTCanHoldConfidentialBalance` can never be changed after issuance.
+- **Default Behavior (Mutable):** By default, without setting `tifMPTCanHoldConfidentialBalance`, the issuer retains the ability to enable the confidential balance setting (`lsfMPTCanHoldConfidentialBalance`) via [`MPTokenIssuanceSet`](https://xrpl.org/docs/references/protocol/transactions/types/mptokenissuanceset) transactions. Enabling is one-way; the flag cannot be cleared once set.
+- **Permanent Lock (Immutable):** If the issuer sets the immutable flag `tifMPTCanHoldConfidentialBalance` through [`MPTokenIssuanceCreate`](https://xrpl.org/docs/references/protocol/transactions/types/mptokenissuancecreate) transaction, the `lsfMPTCanHoldConfidentialBalance` can never be changed after issuance.
 
 #### 6.3.2. Enabling Confidentiality
 
 There are two ways to enable the `lsfMPTCanHoldConfidentialBalance` flag:
 
 - **At Creation:** The issuer can enable the `tfMPTCanHoldConfidentialBalance` flag directly within the `MPTokenIssuanceCreate` transaction at the time the token is issued.
-- **Post-Creation (Update):** If the issuance was created with confidential amount mutability allowed (that is, `lsmfMPTCannotEnableCanHoldConfidentialBalance` was not set — which is the default behavior), the issuer may later submit an `MPTokenIssuanceSet` transaction to activate the `lsfMPTCanHoldConfidentialBalance` flag.
+- **Post-Creation (Update):** If the issuance was created with confidential mutability allowed (that is, `lsifMPTCanHoldConfidentialBalance` was not set — which is the default behavior), the issuer may later submit an `MPTokenIssuanceSet` transaction to activate the `lsfMPTCanHoldConfidentialBalance` flag.
 
 #### 6.3.3. Disabling Confidentiality
 
-Enabling confidentiality is **one-way**. Once `lsfMPTCanHoldConfidentialBalance` is set it cannot be cleared — there is no transaction flag to disable confidential amounts on an existing issuance. This guarantees that funds already converted to a confidential state can never be stranded by the capability being turned off underneath them.
+Enabling confidentiality is **one-way**. Once `lsfMPTCanHoldConfidentialBalance` is set it cannot be cleared — there is no transaction flag to disable confidential balance on an existing issuance. This guarantees that funds already converted to a confidential state can never be stranded by the capability being turned off underneath them.
 
 ### 6.4. Transfer Fee Compatibility
 
@@ -199,9 +184,9 @@ This restriction is required because XLS-33 transfer fees are percentage-based, 
 The following cases are invalid:
 
 - `MPTokenIssuanceCreate` with both a non-zero `TransferFee` and `tfMPTCanHoldConfidentialBalance`. (`temBAD_TRANSFER_FEE`)
-- `MPTokenIssuanceSet` that sets `tmfMPTSetCanHoldConfidentialBalance` while the issuance already has a non-zero `TransferFee`. (`tecNO_PERMISSION`)
+- `MPTokenIssuanceSet` that sets `tfMPTSetCanHoldConfidentialBalance` while the issuance already has a non-zero `TransferFee`. (`tecNO_PERMISSION`)
 - `MPTokenIssuanceSet` that sets a non-zero `TransferFee` while the issuance already has `lsfMPTCanHoldConfidentialBalance`. (`tecNO_PERMISSION`)
-- `MPTokenIssuanceSet` that sets a non-zero `TransferFee` and `tmfMPTSetCanHoldConfidentialBalance` in the same transaction. (`temBAD_TRANSFER_FEE`)
+- `MPTokenIssuanceSet` that sets a non-zero `TransferFee` and `tfMPTSetCanHoldConfidentialBalance` in the same transaction. (`temBAD_TRANSFER_FEE`)
 
 `ConfidentialMPTSend` will fail with `tecNO_PERMISSION` if the issuance has a non-zero `TransferFee`.
 
@@ -289,7 +274,7 @@ This transaction is a **self-conversion only**. The issuer account itself **cann
 ### 7.4. Invariants
 
 - **Deletion Blocker:** A holder's `MPToken` cannot be deleted from the ledger once confidential fields have been initialized, even if `sfConfidentialBalanceSpending`, `sfConfidentialBalanceInbox`, and `sfIssuerEncryptedBalance` all contain the canonical encrypted zero (i.e., the holder's confidential balance is zero). The issuer may delete the `MPTokenIssuance` object only when `sfConfidentialOutstandingAmount` is 0 (in addition to the standard XLS-33 deletion requirements).
-- **Confidential Amount Flag Consistency:** If an `MPToken` contains any encrypted balance fields, then its corresponding `MPTokenIssuance` must have the `lsfMPTCanHoldConfidentialBalance` flag enabled.
+- **Confidential Balance Flag Consistency:** If an `MPToken` contains any encrypted balance fields, then its corresponding `MPTokenIssuance` must have the `lsfMPTCanHoldConfidentialBalance` flag enabled.
 - **Encrypted Field Consistency:** If an `MPToken` contains `sfConfidentialBalanceSpending` or `sfConfidentialBalanceInbox`, then it must also contain `sfIssuerEncryptedBalance` (and vice versa).
 - **Version Modification:** If `sfConfidentialBalanceSpending != sfConfidentialBalanceSpending` (the spending balance is modified), then `sfConfidentialBalanceVersion != sfConfidentialBalanceVersion` (the version must be changed).
 
@@ -366,7 +351,7 @@ This transaction honors **Deposit Authorization** and **Credentials** (XLS-70), 
 
 1. The destination account does not exist. (`tecNO_TARGET`)
 2. The issuance does not have the `lsfMPTCanTransfer` flag set. (`tecNO_AUTH`)
-3. The issuance does not support confidential amounts (`lsfMPTCanHoldConfidentialBalance` is not set). (`tecNO_PERMISSION`)
+3. The issuance does not support confidential balance (`lsfMPTCanHoldConfidentialBalance` is not set). (`tecNO_PERMISSION`)
 4. One of the participating accounts lacks a registered ElGamal public key or required confidential fields (`sfHolderEncryptionKey`, `sfConfidentialBalanceSpending`, etc.). (`tecNO_PERMISSION`)
 5. The provided Zero-Knowledge Proof fails to verify equality or range constraints. (`tecBAD_PROOF`)
 6. Either the sender's or receiver's balance is currently frozen. (`terFROZEN`)
@@ -409,7 +394,7 @@ If the transaction is successful:
 }
 ```
 
-Net effect: Public balances unchanged; confidential amount is redistributed (sender CB_S ↓, receiver CB_IN ↑). OA (plaintext) unchanged; COA (plaintext) unchanged.
+Net effect: Public balances unchanged; confidential balance is redistributed (sender CB_S ↓, receiver CB_IN ↑). OA (plaintext) unchanged; COA (plaintext) unchanged.
 
 ## 9. Transaction: `ConfidentialMPTMergeInbox`
 
@@ -615,6 +600,8 @@ This issuer-only transaction is designed to forcibly burn a holder's entire conf
      3. The global OA is also decreased by the RevealedAmount.
      4. The global `OutstandingAmount` is decreased by `RevealedAmount`, burning the clawed-back tokens. The funds are permanently removed from circulation and are **not** credited to any account.
 
+**Note**: We recommend locking the MPT before clawing back. This prevents the holder from sending any more mpt transactions while the clawback is in progress.
+
 ### 11.2. Fields
 
 | Field Name          | Required? | JSON Type | Internal Type | Default Value | Description                                                                                                                             |
@@ -677,13 +664,13 @@ If the transaction is successful, the holder's confidential state is reset, and 
 
 ## 12. Transaction: `MPTokenIssuanceSet`
 
-The existing `MPTokenIssuanceSet` transaction is extended to manage the confidential lifecycle of an MPT issuance. This includes enabling confidential amount status and registering encryption keys.
+The existing `MPTokenIssuanceSet` transaction is extended to manage the confidential lifecycle of an MPT issuance. This includes enabling confidential balance status and registering encryption keys.
 
 ### 12.1. Usage & Mutability
 
-This transaction is the only method to register keys or enable the confidential amount status (via the `MutableFlags` field with the `tmfMPTSetCanHoldConfidentialBalance` bit flag) of an issuance. However, these actions are subject to strict state constraints to prevent funds from becoming locked or un-auditable.
+This transaction is the only method to register keys or enable the confidential balance status (via the `Flags` field with the `tfMPTSetCanHoldConfidentialBalance` bit flag) of an issuance. However, these actions are subject to strict state constraints to prevent funds from becoming locked or un-auditable.
 
-**Key Registration:** Encryption keys (`IssuerEncryptionKey` and `AuditorEncryptionKey`) can be set in the same transaction that enables the `lsfMPTCanHoldConfidentialBalance` flag using `tmfMPTSetCanHoldConfidentialBalance`, allowing issuers to enable confidential transfers and register keys in a single atomic operation.
+**Key Registration:** Encryption keys (`IssuerEncryptionKey` and `AuditorEncryptionKey`) can be set in the same transaction that enables the `lsfMPTCanHoldConfidentialBalance` flag using `tfMPTSetCanHoldConfidentialBalance`, allowing issuers to enable confidential transfers and register keys in a single atomic operation.
 
 ### 12.2. Fields
 
@@ -694,66 +681,66 @@ The following fields are introduced by this extension to support encryption key 
 | `IssuerEncryptionKey`  | No        | `string`  | `BLOB`        | The 33-byte EC-ElGamal public key used for the issuer's mirror balances.         |
 | `AuditorEncryptionKey` | No        | `string`  | `BLOB`        | The 33-byte EC-ElGamal public key used for regulatory oversight (if applicable). |
 
-The following existing field is extended with a new bit flag to support enabling the confidential amount feature post-issuance:
+The following existing field is extended with a new bit flag to support enabling the confidential balance feature post-issuance:
 
-| Field Name     | Required? | JSON Type | Internal Type | Description                                                                                                                                                                                                                             |
-| :------------- | :-------- | :-------- | :------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MutableFlags` | No        | `number`  | `UINT32`      | Indicates which fields or flags of this token issuance can be modified after creation. See [MPTokenIssuance MutableFlags](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0094-dynamic-MPT#31-new-optional-field-mutableflags). |
+| Field Name       | Required? | JSON Type | Internal Type | Description                                                                                |
+| :--------------- | :-------- | :-------- | :------------ | :----------------------------------------------------------------------------------------- |
+| `ImmutableFlags` | No        | `number`  | `UINT32`      | Indicates which fields or flags of this token issuance can NOT be modified after creation. |
 
-#### 12.2.1. `MutableFlags` Bit Flags
+### 12.3. Flags
 
-The following bit flag is added to the `MutableFlags` field to enable the confidential amount feature:
+The following bit flag is added to the `Flags` field to enable the confidential balance feature:
 
-| Flag Name                             | Hex Value    | Decimal Value | Description                                                                                                                                          |
-| :------------------------------------ | :----------- | :------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tmfMPTSetCanHoldConfidentialBalance` | `0x00000040` | 64            | Sets the `lsfMPTCanHoldConfidentialBalance` flag on the `MPTokenIssuance`. Only valid if `lsmfMPTCannotEnableCanHoldConfidentialBalance` is not set. |
+| Flag Name                            | Hex Value    | Decimal Value | Description                                                                                                                              |
+| :----------------------------------- | :----------- | :------------ | :--------------------------------------------------------------------------------------------------------------------------------------- |
+| `tfMPTSetCanHoldConfidentialBalance` | `0x00000100` | 256           | Sets the `lsfMPTCanHoldConfidentialBalance` flag on the `MPTokenIssuance`. Only valid if `lsifMPTCanHoldConfidentialBalance` is not set. |
 
 **Usage Notes:**
 
-- These flags can only be used if the `lsmfMPTCannotEnableCanHoldConfidentialBalance` flag was **not** set during `MPTokenIssuanceCreate`.
-- Setting `tmfMPTSetCanHoldConfidentialBalance` enables confidential transfers for the token.
+- These flags can only be used if the `lsifMPTCanHoldConfidentialBalance` flag was **not** set under `sfImmutableFlags` during `MPTokenIssuanceCreate`.
+- Setting `tfMPTSetCanHoldConfidentialBalance` enables confidential transfers for the token.
 - Enabling confidential transfers is one-way: there is no flag to clear `lsfMPTCanHoldConfidentialBalance` once it has been set.
 
-### 12.3. Failure Conditions
+### 12.4. Failure Conditions
 
-#### 12.3.1. Data Verification
+#### 12.4.1. Data Verification
 
 1. The `featureConfidentialTransfer` is not enabled. (`temDISABLED`)
 2. The provided Public Key is not exactly 33 bytes (`ecPubKeyLength`). (`temMALFORMED`)
 3. The transaction attempts to mutate confidential amount fields while also acting as a Holder. (`temMALFORMED`)
 4. The transaction contains `sfAuditorEncryptionKey` but does **not** contain `sfIssuerEncryptionKey`. (`temMALFORMED`)
 
-#### 12.3.2. Protocol-Level Failures
+#### 12.4.2. Protocol-Level Failures
 
-1. The transaction attempts to use `tmfMPTCanHoldConfidentialBalance`, but the `lsmfMPTCannotEnableCanHoldConfidentialBalance` flag is set (feature is immutable). (`tecNO_PERMISSION`)
+1. The transaction attempts to use `tfMPTCanHoldConfidentialBalance`, but the `lsifMPTCanHoldConfidentialBalance` flag is set in sfImmutableFlags. (`tecNO_PERMISSION`)
 2. The transaction provides a `sfIssuerEncryptionKey` (or Auditor Key), but the issuance object **already** has one. (`tecNO_PERMISSION`)
 3. The transaction provides a `sfIssuerEncryptionKey`, but the issuance does not have the `lsfMPTCanHoldConfidentialBalance` flag enabled.
-   - **Exception:** Keys can be set if the `lsfMPTCanHoldConfidentialBalance` flag is being enabled in the same transaction via `tmfMPTSetCanHoldConfidentialBalance`. (`tecNO_PERMISSION`)
+   - **Exception:** Keys can be set if the `lsfMPTCanHoldConfidentialBalance` flag is being enabled in the same transaction via `tfMPTSetCanHoldConfidentialBalance`. (`tecNO_PERMISSION`)
 4. The transaction attempts to upload keys, but the `sfConfidentialOutstandingAmount` field is already present (tokens are already in circulation). (`tecNO_PERMISSION`)
 
-### 12.4. State Changes
+### 12.5. State Changes
 
 If successful:
 
 - **Flags:** The `lsfMPTCanHoldConfidentialBalance` flag is updated (if mutable).
 - **Keys:** The `sfIssuerEncryptionKey` and/or `sfAuditorEncryptionKey` are stored on the `MPTokenIssuance` ledger entry.
 
-### 12.5. Example JSON
+### 12.6. Example JSON
 
-#### 12.5.1. Enabling Confidential Amount Feature
+#### 12.6.1. Enabling Confidential Balance Feature
 
 ```json
 {
   "Account": "rIssuerAccount...",
   "TransactionType": "MPTokenIssuanceSet",
   "MPTokenIssuanceID": "610F33...",
-  "MutableFlags": 64, // tmfMPTSetCanHoldConfidentialBalance
+  "Flags": 256, // tfMPTSetCanHoldConfidentialBalance
   "IssuerEncryptionKey": "028d...",
   "AuditorEncryptionKey": "037c..."
 }
 ```
 
-This transaction enables the confidential amount feature by setting the `tmfMPTSetCanHoldConfidentialBalance` bit flag in the `MutableFlags` field, and simultaneously registers the encryption keys in the same atomic operation. This demonstrates that keys can be set when the `lsfMPTCanHoldConfidentialBalance` flag is being enabled in the same transaction.
+This transaction enables the confidential balance feature by setting the `tfMPTSetCanHoldConfidentialBalance` bit flag in the `Flags` field, and simultaneously registers the encryption keys in the same atomic operation. This demonstrates that keys can be set when the `lsfMPTCanHoldConfidentialBalance` flag is being enabled in the same transaction.
 
 ## 13. Operational Considerations
 

--- a/.agents/skills/xrpl-standards/scripts/sync-xls-standards.py
+++ b/.agents/skills/xrpl-standards/scripts/sync-xls-standards.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Sync local XRPL-Standards markdown references from upstream."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+REPO = "XRPLF/XRPL-Standards"
+ROOT_API = f"https://api.github.com/repos/{REPO}/contents"
+RAW_BASE = f"https://raw.githubusercontent.com/{REPO}/master"
+
+
+@dataclass
+class SyncRecord:
+    number: int
+    remote_dir: str
+    local_path: Path
+    title: str = "Unknown"
+    status: str = "Unknown"
+    added: bool = False
+
+
+def request_json(url: str, token: str | None = None) -> Any:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "xrpl-go-skills-sync",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    req = Request(url, headers=headers)
+    with urlopen(req, timeout=60) as response:
+        text = response.read().decode("utf-8")
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Failed to parse JSON from {url}: {exc}") from exc
+
+
+def request_text(url: str, token: str | None = None) -> str:
+    headers = {
+        "User-Agent": "xrpl-go-skills-sync",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    req = Request(url, headers=headers)
+    with urlopen(req, timeout=60) as response:
+        return response.read().decode("utf-8")
+
+
+def extract_markdown(readme_text: str, extract_script: Path) -> str:
+    proc = subprocess.run(
+        [sys.executable, str(extract_script)],
+        input=readme_text.encode("utf-8"),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.decode("utf-8").strip())
+
+    return proc.stdout.decode("utf-8")
+
+
+def parse_frontmatter(markdown: str) -> dict[str, str]:
+    lines = markdown.splitlines()
+    start = None
+    end_token = None
+
+    for index, line in enumerate(lines):
+        token = line.strip()
+        if token == "<pre>" or token == "---":
+            start = index + 1
+            end_token = "</pre>" if token == "<pre>" else "---"
+            break
+
+    if start is None:
+        return {}
+
+    end = None
+    for index in range(start, len(lines)):
+        if lines[index].strip() == end_token:
+            end = index
+            break
+
+    if end is None:
+        return {}
+
+    result: dict[str, str] = {}
+    for entry in lines[start:end]:
+        if ":" not in entry:
+            continue
+        key, value = entry.split(":", 1)
+        result[key.strip()] = value.strip().strip('"').strip("'")
+
+    return result
+
+
+def parse_xls_number_from_file(name: str) -> int | None:
+    match = re.fullmatch(r"xls-(\d{4})\.md", name.lower())
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except ValueError:
+        return None
+
+
+def read_local_references(reference_dir: Path) -> dict[int, Path]:
+    known: dict[int, Path] = {}
+    for file_path in reference_dir.glob("**/*.md"):
+        if file_path.name == "INDEX.md":
+            continue
+
+        number = parse_xls_number_from_file(file_path.name)
+        if number is None:
+            continue
+
+        # Keep the first file for a number when duplicates exist.
+        known.setdefault(number, file_path)
+
+    return known
+
+
+def list_remote_directories(token: str | None) -> list[tuple[int, str]]:
+    data = request_json(ROOT_API, token=token)
+    pattern = re.compile(r"^XLS-(\d+)", re.IGNORECASE)
+
+    items: list[tuple[int, str]] = []
+    for item in data:
+        if item.get("type") != "dir":
+            continue
+
+        name = item.get("name", "")
+        match = pattern.match(name)
+        if not match:
+            continue
+
+        try:
+            items.append((int(match.group(1)), name))
+        except ValueError:
+            continue
+
+    return sorted(items, key=lambda value: value[0])
+
+
+def generate_index_entries(reference_dir: Path) -> dict[str, list[tuple[int, str, str, str]]]:
+    by_category: dict[str, list[tuple[int, str, str, str]]] = {}
+
+    for file_path in sorted(reference_dir.glob("**/*.md")):
+        if file_path.name == "INDEX.md":
+            continue
+
+        number = parse_xls_number_from_file(file_path.name)
+        if number is None:
+            continue
+
+        meta = parse_frontmatter(file_path.read_text(encoding="utf-8"))
+        title = meta.get("title", "Unknown")
+        status = meta.get("status", "Unknown")
+
+        rel = file_path.relative_to(reference_dir)
+        category = rel.parts[0]
+        by_category.setdefault(category, []).append(
+            (number, title, status, str(Path("references") / rel).replace("\\", "/"))
+        )
+
+    for rows in by_category.values():
+        rows.sort(key=lambda value: value[0])
+
+    return by_category
+
+
+def render_index(entries: dict[str, list[tuple[int, str, str, str]]]) -> str:
+    lines = ["# XRPL Standards Index", ""]
+
+    category_order = [
+        "identity",
+        "tokens",
+        "defi",
+        "payments",
+        "accounts",
+        "data",
+        "cross-chain",
+        "smart-contracts",
+        "core",
+        "ecosystem",
+        "UNCLASSIFIED",
+    ]
+
+    additional = sorted(set(entries.keys()) - set(category_order))
+    ordered_categories = [name for name in category_order if name in entries]
+    ordered_categories.extend(name for name in additional if name not in ordered_categories)
+
+    for category in ordered_categories:
+        rows = entries[category]
+        if not rows:
+            continue
+
+        lines.append(f"## {category}")
+        lines.append("| XLS | Title | Status | File |")
+        lines.append("| ----- | ------- | -------- | ------ |")
+        for number, raw_title, raw_status, file_path in rows:
+            title = str(raw_title).replace("|", "\\|")
+            lines.append(f"| {number} | {title} | {raw_status} | `{file_path}` |")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def safe_write(path: Path, content: str, dry_run: bool) -> bool:
+    current = path.read_text(encoding="utf-8") if path.exists() else ""
+    if current == content:
+        return False
+
+    if dry_run:
+        return True
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return True
+
+
+def sync(
+    skill_dir: Path,
+    token: str | None,
+    dry_run: bool,
+    *,
+    use_full_text: bool = True,
+) -> tuple[list[SyncRecord], list[SyncRecord], list[str]]:
+    reference_dir = skill_dir / "references"
+    extract_script = skill_dir / "scripts" / "extract-spec.py"
+    index_path = reference_dir / "INDEX.md"
+
+    local_map = read_local_references(reference_dir)
+    updates: list[SyncRecord] = []
+    added: list[SyncRecord] = []
+    notes: list[str] = []
+
+    remote_items = list_remote_directories(token)
+    for number, remote_dir in remote_items:
+        readme_url = f"{RAW_BASE}/{remote_dir}/README.md"
+
+        try:
+            readme_raw = request_text(readme_url, token=token)
+        except HTTPError as exc:
+            notes.append(f"XLS-{number}: failed readme fetch ({exc.code})")
+            continue
+        except URLError as exc:
+            notes.append(f"XLS-{number}: failed readme fetch ({exc.reason})")
+            continue
+
+        if use_full_text:
+            body = readme_raw
+        else:
+            try:
+                body = extract_markdown(readme_raw, extract_script).rstrip("\n") + "\n"
+            except Exception as exc:
+                notes.append(f"XLS-{number}: extractor failed ({exc})")
+                continue
+
+        metadata = parse_frontmatter(readme_raw)
+        title = metadata.get("title", "Unknown")
+        status = metadata.get("status", "Unknown")
+
+        target = local_map.get(number)
+        added_xls = False
+        if target is None:
+            target = reference_dir / "UNCLASSIFIED" / f"xls-{number:04d}.md"
+            added_xls = True
+
+        changed = safe_write(target, body, dry_run)
+        if changed:
+            record = SyncRecord(
+                number=number,
+                remote_dir=remote_dir,
+                local_path=target,
+                title=title,
+                status=status,
+                added=added_xls,
+            )
+            if added_xls:
+                added.append(record)
+            else:
+                updates.append(record)
+
+            local_map[number] = target
+
+    index_entries = generate_index_entries(reference_dir)
+    index_content = render_index(index_entries)
+    if safe_write(index_path, index_content, dry_run):
+        notes.append("INDEX.md updated")
+
+    return updates, added, notes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Update XRPL-Standards references from upstream")
+    parser.add_argument(
+        "--skill-dir",
+        default=str(Path(__file__).resolve().parents[1]),
+        help="Path to xrpl-standards skill directory",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Do not write files")
+    parser.add_argument("--json", action="store_true", help="Print JSON summary")
+    parser.add_argument(
+        "--extract",
+        action="store_true",
+        help="Write extracted summary instead of full remote README.md content",
+    )
+
+    args = parser.parse_args()
+
+    skill_dir = Path(args.skill_dir).resolve()
+    if not skill_dir.is_dir():
+        print(f"Error: skill directory not found: {skill_dir}", file=sys.stderr)
+        return 1
+
+    token = None
+    for env_name in ("GITHUB_TOKEN", "GH_TOKEN", "TOKEN"):
+        value = os.environ.get(env_name)
+        if value:
+            token = value
+            break
+
+    try:
+        updates, added, notes = sync(skill_dir, token, args.dry_run, use_full_text=not args.extract)
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    summary = {
+        "updated": [
+            {
+                "number": item.number,
+                "title": item.title,
+                "status": item.status,
+                "remote_dir": item.remote_dir,
+                "local_path": str(item.local_path),
+            }
+            for item in updates
+        ],
+        "added": [
+            {
+                "number": item.number,
+                "title": item.title,
+                "status": item.status,
+                "remote_dir": item.remote_dir,
+                "local_path": str(item.local_path),
+            }
+            for item in added
+        ],
+        "notes": notes,
+    }
+
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        for line in notes:
+            print(f"- {line}")
+        print(f"Updated: {len(summary['updated'])}")
+        print(f"Added: {len(summary['added'])}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/sync-xrpl-standards.yml
+++ b/.github/workflows/sync-xrpl-standards.yml
@@ -31,7 +31,7 @@ jobs:
         id: refs
         run: |
           set -eu
-          if git diff --quiet -- .agents/skills/xrpl-standards/references; then
+          if [ -z "$(git status --porcelain -- .agents/skills/xrpl-standards/references)" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No reference changes found."
             exit 0
@@ -39,9 +39,9 @@ jobs:
 
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
           echo "### XRPL-Standards reference changes" > /tmp/xls_summary.txt
-          git diff -- .agents/skills/xrpl-standards/references --stat >> /tmp/xls_summary.txt
+          git diff --stat -- .agents/skills/xrpl-standards/references >> /tmp/xls_summary.txt
           echo "diff_summary<<EOF" >> "$GITHUB_OUTPUT"
-          cat /tmp/xls_summary.txt
+          cat /tmp/xls_summary.txt >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Open pull request

--- a/.github/workflows/sync-xrpl-standards.yml
+++ b/.github/workflows/sync-xrpl-standards.yml
@@ -1,0 +1,65 @@
+name: Sync XRPL Standards references
+
+on:
+  schedule:
+    # Every Monday and Thursday, 06:00 UTC.
+    - cron: "0 6 * * 1,4"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-xrpl-standards:
+    name: Update XRPL-Standards references
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: true
+
+      - name: Run XRPL-Standards sync script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .agents/skills/xrpl-standards/scripts/sync-xls-standards.py
+
+      - name: Check for reference changes
+        id: refs
+        run: |
+          set -eu
+          if git diff --quiet -- .agents/skills/xrpl-standards/references; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No reference changes found."
+            exit 0
+          fi
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          echo "### XRPL-Standards reference changes" > /tmp/xls_summary.txt
+          git diff -- .agents/skills/xrpl-standards/references --stat >> /tmp/xls_summary.txt
+          echo "diff_summary<<EOF" >> "$GITHUB_OUTPUT"
+          cat /tmp/xls_summary.txt
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Open pull request
+        if: steps.refs.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/auto-update-xrpl-standards
+          commit-message: "chore(skills): sync XRPL-Standards references"
+          title: "chore(skills): sync XRPL-Standards references"
+          body: |
+            Automated sync from https://github.com/XRPLF/XRPL-Standards.
+            Includes updates to existing references and new XLS files in
+            `references/UNCLASSIFIED` when the folder is not known.
+
+            ${{ steps.refs.outputs.diff_summary }}
+          add-paths: |
+            .agents/skills/xrpl-standards/references
+          labels: |
+            automation
+            xrpl-standards


### PR DESCRIPTION
# chore(skills): automate XRPL-Standards reference sync

## Description
This PR aims to automate periodic XRPL-Standards reference syncing by adding a sync script and scheduled workflow.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes

## Changes
- Add `.agents/skills/xrpl-standards/scripts/sync-xls-standards.py`.
- Add `.github/workflows/sync-xrpl-standards.yml` with Monday/Thursday schedule and auto-PR creation.
- Update `.agents/skills/xrpl-standards/SKILL.md` refresh usage and full-vs-extract behavior.
- Refresh two reference files with upstream metadata updates.
